### PR TITLE
fix (Gen1): replace deprecated Q with native Promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,6 @@
     "@types/eslint-scope": "^3.7.3",
     "@types/jquery": "^3.5.14",
     "@types/jqueryui": "^1.12.16",
-    "@types/q": "^1.5.5",
     "@types/selectize": "^0.12.35",
     "@types/underscore": "^1.11.4",
     "chokidar": "^3.5.1",
@@ -264,7 +263,6 @@
     "handlebars": "^4.7.9",
     "jquery": "^3.6.0",
     "parse-ms": "^2.0.0",
-    "q": "1.4.1",
     "u2f-api-polyfill": "0.4.3",
     "underscore": "1.13.8"
   },

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -15,7 +15,6 @@
 import { _, Model, loc, internal, ModelProperty } from '@okta/courage';
 import config from 'config/config.json';
 import hbs from '@okta/handlebars-inline-precompile';
-import Q from 'q';
 import BrowserFeatures from 'util/BrowserFeatures';
 import {
   ConfigError,
@@ -522,7 +521,7 @@ export default class Settings extends Model {
   processCreds(creds) {
     const processCreds = this.get('processCreds');
 
-    return Q.Promise(function(resolve) {
+    return new Promise<void>(function(resolve) {
       if (!_.isFunction(processCreds)) {
         resolve();
       } else if (processCreds.length === 2) {

--- a/src/util/Animations.js
+++ b/src/util/Animations.js
@@ -12,13 +12,13 @@
 
 /* eslint max-statements: [2, 16] */
 
-import Q from 'q';
+import { createDeferred } from './createDeferred';
 import Enums from './Enums';
 const SWAP_PAGE_TIME = 200;
 const fn = {};
 
 function zoom($el, start, finish) {
-  const deferred = Q.defer();
+  const deferred = createDeferred();
 
   $el.animate(
     {
@@ -41,7 +41,7 @@ function zoom($el, start, finish) {
 }
 
 function rotate($el, start, finish) {
-  const deferred = Q.defer();
+  const deferred = createDeferred();
 
   $el.animate(
     {
@@ -67,7 +67,7 @@ function rotate($el, start, finish) {
 // remove the old dom node (and controller) in the same tick of the event
 // loop. Waiting for "then" results in a glitchy animation.
 fn.swapPages = function(options) {
-  const deferred = Q.defer();
+  const deferred = createDeferred();
   const $parent = options.$parent;
   const $oldRoot = options.$oldRoot;
   const $newRoot = options.$newRoot;

--- a/src/util/createDeferred.ts
+++ b/src/util/createDeferred.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) 2025, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export interface Deferred<T = unknown> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+/**
+ * Creates a "deferred" - a promise together with its resolve/reject functions
+ * exposed externally. This replaces the deprecated `Q.defer()` for the cases
+ * where the promise is settled from an outside callback (jQuery animations,
+ * u2f callbacks, timeouts, etc.) and a `new Promise(executor)` wrapper would be
+ * awkward.
+ */
+export function createDeferred<T = unknown>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export default createDeferred;

--- a/src/util/delay.ts
+++ b/src/util/delay.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) 2025, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * Resolves after `ms` milliseconds. Native replacement for the deprecated
+ * `Q.delay`. Exposed as a method on a default-exported object (rather than a
+ * bare named export) so tests can `spyOn(DelayUtil, 'delay')` to fast-forward
+ * timing - mirroring how `Q.delay` used to be mocked.
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default { delay };

--- a/src/util/webauthn.js
+++ b/src/util/webauthn.js
@@ -10,11 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import Q from 'q';
 import FidoUtil from 'util/FidoUtil';
 
 function adaptToOkta(promise) {
-  return new Q(promise);
+  return Promise.resolve(promise);
 }
 
 function makeCredential(accountInfo, cryptoParams, challenge) {

--- a/src/v1/controllers/EnrollDuoController.js
+++ b/src/v1/controllers/EnrollDuoController.js
@@ -13,7 +13,6 @@
 /* eslint camelcase: 0*/
 import { $, _, loc } from '@okta/courage';
 import Duo from '@okta/duo';
-import Q from 'q';
 import FormController from 'v1/util/FormController';
 import Footer from 'v1/views/enroll-factors/Footer';
 export default FormController.extend({
@@ -56,7 +55,7 @@ export default FormController.extend({
       // jquery decides the Content-Type instead of it being a JSON type). Enroll/Verify DUO
       // are the only two places where we actually do this.
       // NOTE - If we ever decide to change this, we should test this very carefully.
-      return Q($.post(url, data))
+      return Promise.resolve($.post(url, data))
         .then(function() {
           return self.doTransaction(function(transaction) {
             return transaction.poll();

--- a/src/v1/controllers/EnrollU2FController.js
+++ b/src/v1/controllers/EnrollU2FController.js
@@ -13,7 +13,7 @@
 /* global u2f */
 import { _, loc, View } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import 'u2f-api-polyfill';
 import { U2FError } from 'util/Errors';
 import FidoUtil from 'util/FidoUtil';
@@ -59,7 +59,7 @@ export default FormController.extend({
           },
         ];
         const self = this;
-        const deferred = Q.defer();
+        const deferred = createDeferred();
 
         u2f.register(appId, registerRequests, [], function(data) {
           self.trigger('errors:clear');
@@ -85,7 +85,8 @@ export default FormController.extend({
           }
         });
         return deferred.promise;
-      });
+      })
+        .catch(() => {});
     },
   },
 

--- a/src/v1/controllers/EnrollWebauthnController.js
+++ b/src/v1/controllers/EnrollWebauthnController.js
@@ -12,7 +12,6 @@
 
 import { _, loc, View } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
-import Q from 'q';
 import BrowserFeatures from 'util/BrowserFeatures';
 import CryptoUtil from 'util/CryptoUtil';
 import { WebauthnAbortError, WebAuthnError } from 'util/Errors';
@@ -89,7 +88,7 @@ export default FormController.extend({
           if (typeof AbortController !== 'undefined') {
             self.webauthnAbortController = new AbortController();
           }
-          return new Q(
+          return Promise.resolve(
             navigator.credentials.create({
               publicKey: options,
               signal: self.webauthnAbortController && self.webauthnAbortController.signal,
@@ -124,7 +123,8 @@ export default FormController.extend({
               self.webauthnAbortController = null;
             });
         }
-      });
+      })
+        .catch(() => {});
     },
   },
 

--- a/src/v1/controllers/RefreshAuthStateController.js
+++ b/src/v1/controllers/RefreshAuthStateController.js
@@ -40,7 +40,10 @@ export default FormController.extend({
       }
 
       appState.trigger('navigate', '');
-    });
+    })
+      // startTransaction already surfaces failures via the 'error' event; swallow
+      // the rejection it re-throws so it does not become an unhandled rejection.
+      .catch(() => {});
   },
 
   remove: function() {

--- a/src/v1/controllers/RegistrationController.js
+++ b/src/v1/controllers/RegistrationController.js
@@ -13,7 +13,6 @@ import { _, Backbone, Model, loc, Form, View } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
 import LoginModel from 'v1/models/LoginModel';
 import RegistrationSchema from 'v1/models/RegistrationSchema';
-import Q from 'q';
 import BaseLoginController from 'v1/util/BaseLoginController';
 import Enums from 'util/Enums';
 import { RegistrationError } from 'util/Errors';
@@ -289,8 +288,8 @@ export default BaseLoginController.extend({
         form.add(requiredFieldsLabel);
       }
     });
-    // fetch schema from API, returns a jqXHR. Wrap it in a Q
-    return Q(this.state.get('schema').fetch());
+    // fetch schema from API, returns a jqXHR. Wrap it in a native Promise
+    return Promise.resolve(this.state.get('schema').fetch());
   },
   Footer: RegistrationControllerFooter,
 });

--- a/src/v1/controllers/VerifyDuoController.js
+++ b/src/v1/controllers/VerifyDuoController.js
@@ -13,7 +13,6 @@
 /* eslint camelcase: 0 */
 import { $, _, loc } from '@okta/courage';
 import Duo from '@okta/duo';
-import Q from 'q';
 import FactorUtil from 'util/FactorUtil';
 import FormController from 'v1/util/FormController';
 import FooterMFA from 'v1/views/shared/FooterMFA';
@@ -78,7 +77,7 @@ export default FormController.extend({
       // are the only two places where we actually do this.
       // NOTE - If we ever decide to change this, we should test this very carefully.
 
-      return Q($.post(url, data))
+      return Promise.resolve($.post(url, data))
         .then(function() {
           return self.doTransaction(function(transaction) {
             let data;

--- a/src/v1/controllers/VerifyU2FController.js
+++ b/src/v1/controllers/VerifyU2FController.js
@@ -13,7 +13,7 @@
 /* global u2f */
 import { _, loc, View } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import 'u2f-api-polyfill';
 import { U2FError } from 'util/Errors';
 import FactorUtil from 'util/FactorUtil';
@@ -88,7 +88,7 @@ export default FormController.extend({
           }
           self.trigger('request');
 
-          const deferred = Q.defer();
+          const deferred = createDeferred();
 
           u2f.sign(appId, nonce, registeredKeys, function(data) {
             self.trigger('errors:clear');

--- a/src/v1/controllers/VerifyWebauthnController.js
+++ b/src/v1/controllers/VerifyWebauthnController.js
@@ -13,7 +13,6 @@
 /* eslint complexity:[2, 10], max-params: [2, 11] */
 import { _, loc, View } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
-import Q from 'q';
 import CryptoUtil from 'util/CryptoUtil';
 import { WebauthnAbortError, WebAuthnError } from 'util/Errors';
 import FactorUtil from 'util/FactorUtil';
@@ -103,7 +102,7 @@ export default FormController.extend({
           if (typeof AbortController !== 'undefined') {
             self.webauthnAbortController = new AbortController();
           }
-          return new Q(
+          return Promise.resolve(
             // navigator.credentials is not supported in IE11
             // eslint-disable-next-line compat/compat
             navigator.credentials.get({

--- a/src/v1/models/AppState.js
+++ b/src/v1/models/AppState.js
@@ -12,7 +12,6 @@
 
 import { _, $, loc, Model } from '@okta/courage';
 import Factor from 'v1/models/Factor';
-import Q from 'q';
 import BrowserFeatures from 'util/BrowserFeatures';
 import { UnsupportedBrowserError } from 'util/Errors';
 const DEFAULT_APP_LOGO = '/img/logos/default.png';
@@ -38,7 +37,7 @@ export function getSecurityImageUrl(baseUrl, username) {
 function getSecurityImage(baseUrl, username, deviceFingerprint) {
   // When the username is empty, we want to show the default image.
   if (_.isEmpty(username) || _.isUndefined(username)) {
-    return Q({
+    return Promise.resolve({
       securityImage: UNDEFINED_USER,
       securityImageDescription: UNDEFINED_USER_IMAGE_DESCRIPTION,
     });
@@ -54,7 +53,7 @@ function getSecurityImage(baseUrl, username, deviceFingerprint) {
   if (deviceFingerprint) {
     data['headers'] = { 'X-Device-Fingerprint': deviceFingerprint };
   }
-  return Q($.ajax(data)).then(function(res) {
+  return Promise.resolve($.ajax(data)).then(function(res) {
     if (res.pwdImg === USER_NOT_SEEN_ON_DEVICE) {
       // When we get an unknown.png security image from OKTA,
       // we want to show the unknown-device security image.
@@ -131,15 +130,14 @@ export default Model.extend({
             model.set('securityImageDescription', image.securityImageDescription);
             model.unset('deviceFingerprint'); //Fingerprint can only be used once
           })
-          .fail(function(jqXhr) {
+          .catch(function(jqXhr) {
             // Only notify the consumer on a CORS error
             if (BrowserFeatures.corsIsNotEnabled(jqXhr)) {
               self.settings.callGlobalError(new UnsupportedBrowserError(loc('error.enabled.cors')));
             } else {
               self.settings.callGlobalError(new Error(`Failed to fetch security image: ${jqXhr.statusText}`));
             }
-          })
-          .done();
+          });
       });
     }
   },

--- a/src/v1/models/BaseLoginModel.js
+++ b/src/v1/models/BaseLoginModel.js
@@ -11,7 +11,6 @@
  */
 
 import { _, Model } from '@okta/courage';
-import Q from 'q';
 import Enums from 'util/Enums';
 const KNOWN_ERRORS = ['OAuthError', 'AuthSdkError', 'AuthPollStopError', 'AuthApiError'];
 export default Model.extend({
@@ -26,7 +25,7 @@ export default Model.extend({
         return trans;
       })
       .catch(function(err) {
-        // Q may still consider AuthPollStopError to be unhandled
+        // These are expected control-flow errors - swallow them instead of surfacing as failures
         if (
           err.name === 'AuthPollStopError' ||
           err.name === Enums.AUTH_STOP_POLL_INITIATION_ERROR ||
@@ -47,7 +46,7 @@ export default Model.extend({
     const res = fn.call(this, this.appState.get('transaction'), _.bind(this.setTransaction, this));
 
     // If it's a promise, listen for failures
-    if (Q.isPromiseAlike(res)) {
+    if (res && typeof res.then === 'function') {
       return res.catch(function(err) {
         if (
           err.name === 'AuthPollStopError' ||
@@ -61,7 +60,7 @@ export default Model.extend({
       });
     }
 
-    return Q.resolve(res);
+    return Promise.resolve(res);
   },
 
   startTransaction: function(fn) {
@@ -69,7 +68,7 @@ export default Model.extend({
     const res = fn.call(this, this.settings.getAuthClient());
 
     // If it's a promise, then chain to it
-    if (Q.isPromiseAlike(res)) {
+    if (res && typeof res.then === 'function') {
       return res
         .then(function(trans) {
           self.trigger('setTransaction', trans);
@@ -82,7 +81,7 @@ export default Model.extend({
         });
     }
 
-    return Q.resolve(res);
+    return Promise.resolve(res);
   },
 
   setTransaction: function(trans) {

--- a/src/v1/models/Factor.js
+++ b/src/v1/models/Factor.js
@@ -11,7 +11,7 @@
  */
 /* eslint complexity: [2, 13] */
 import { _, loc, Collection } from '@okta/courage';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import { AuthStopPollInitiationError } from 'util/Errors';
 import factorUtil from 'util/FactorUtil';
 import Util from 'util/Util';
@@ -312,7 +312,7 @@ const FactorFactor = BaseLoginModel.extend({
         setTransaction(trans);
         // In Okta verify case we initiate poll.
         if ((trans.status === 'MFA_CHALLENGE' && trans.poll) || (trans.status === 'FACTOR_CHALLENGE' && trans.poll)) {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
           const cancelPollInitiation = Util.callAfterTimeoutOrWindowRefocus(deferred.resolve, PUSH_INTERVAL);
           self.listenToOnce(self.options.appState, 'factorSwitched', () => {
             cancelPollInitiation();
@@ -333,16 +333,16 @@ const FactorFactor = BaseLoginModel.extend({
             let innerPromise;
             if (BrowserFeatures.isIOS()) {
               let cancelRedundantPoll;
-              innerPromise = Q.race([
+              innerPromise = Promise.race([
                 trans.poll(options),
                 (() => {
-                  const _deferred = Q.defer();
+                  const _deferred = createDeferred();
                   cancelRedundantPoll = Util.callAfterTimeoutOrWindowRefocus(_deferred.resolve, 2000, true);
                   return _deferred.promise.then(() => {
                     if (!pollingHasStarted) {
                       return trans.poll(options);
                     }
-                    return Q.defer().promise;   // never resolve this promise
+                    return new Promise(() => {});   // never resolve this promise
                   });
                 })()
               ])

--- a/src/v1/util/BaseLoginController.js
+++ b/src/v1/util/BaseLoginController.js
@@ -11,8 +11,6 @@
  */
 
 import { _, Form, Controller } from '@okta/courage';
-import Q from 'q';
-
 function getForm(controller) {
   return _.find(controller.getChildren(), function(item) {
     return item instanceof Form;
@@ -80,7 +78,7 @@ export default Controller.extend({
   // question, which requires an additional request to fetch the question
   // list.
   fetchInitialData: function() {
-    return Q();
+    return Promise.resolve();
   },
 
   // Override this method to prevent route navigation. This is useful for

--- a/src/v1/views/factor-verify/EmailMagicLinkForm.js
+++ b/src/v1/views/factor-verify/EmailMagicLinkForm.js
@@ -11,8 +11,8 @@
  */
 /* eslint complexity: [2, 7] */
 import { Form, createButton, loc } from '@okta/courage';
-import Q from 'q';
 import Enums from 'util/Enums';
+import DelayUtil from 'util/delay';
 export default Form.extend({
   layout: 'o-form-theme',
   className: 'factor-verify-magiclink',
@@ -41,7 +41,7 @@ export default Form.extend({
           this.model
             .save()
             .then(() => {
-              return Q.delay(Enums.API_RATE_LIMIT);
+              return DelayUtil.delay(Enums.API_RATE_LIMIT);
             })
             .then(() => {
               this.options.title = loc('mfa.resendEmail', 'login');

--- a/src/v1/views/mfa-verify/PassCodeForm.js
+++ b/src/v1/views/mfa-verify/PassCodeForm.js
@@ -13,8 +13,8 @@
 /* eslint complexity: [2, 7] */
 import { _, loc, Form, createButton, View } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
-import Q from 'q';
 import Enums from 'util/Enums';
+import DelayUtil from 'util/delay';
 import TextBox from 'v1/views/shared/TextBox';
 const subtitleTpl = hbs('({{subtitle}})');
 const PassCodeFormwarningTemplate = View.extend({
@@ -140,7 +140,7 @@ export default Form.extend({
             .then(function() {
               // render and focus on the passcode input field.
               form.getInputs().first().render().focus();
-              return Q.delay(Enums.API_RATE_LIMIT);
+              return DelayUtil.delay(Enums.API_RATE_LIMIT);
             })
             .then(() => {
               this.options.title = formAndButtonDetails.formRetry;

--- a/src/v1/views/shared/FactorBeacon.js
+++ b/src/v1/views/shared/FactorBeacon.js
@@ -14,7 +14,7 @@
 import { View } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
 import Factor from 'v1/models/Factor';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import FactorUtil from 'util/FactorUtil';
 import FactorsDropDown from 'v1/views/mfa-verify/dropdown/FactorsDropDown';
 export default View.extend({
@@ -73,7 +73,7 @@ export default View.extend({
   },
 
   fadeOut: function() {
-    const deferred = Q.defer();
+    const deferred = createDeferred();
 
     this.$('.auth-beacon-factor').fadeOut(200, function() {
       deferred.resolve();

--- a/src/v1/views/shared/Header.ts
+++ b/src/v1/views/shared/Header.ts
@@ -124,8 +124,7 @@ export default class Header extends View {
       return Animations.implode(container)
         .then(() => {
           removeBeacon(this);
-        })
-        .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
+        });
     case 'fade':
       // Other transitions are performed on the beacon container,
       // but this transition is on the content inside the beacon.
@@ -143,8 +142,7 @@ export default class Header extends View {
         .then(() => {
           removeBeacon(this);
           addBeacon(this, NextBeacon, selector, options);
-        })
-        .done(); // TODO: can this be removed if fadeOut returns standard ES6 Promise?
+        });
     case 'swap':
       return Animations.swapBeacons({
         $el: container,
@@ -160,7 +158,7 @@ export default class Header extends View {
           }
           addBeacon(this, NextBeacon, selector, options);
         },
-      }).done(); // TODO: can this be removed if Animations.swapBeacons returns standard ES6 Promise?
+      });
     case 'load':
       // Show the loading beacon. Add a couple of classes
       // before triggering the add beacon code.
@@ -195,8 +193,7 @@ export default class Header extends View {
       .then(() => {
         removeBeacon(this);
         container.removeClass(LOADING_BEACON_CLS);
-      })
-      .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
+      });
   }
 
   getTemplateData() {

--- a/test/unit/helpers/mocks/AuthClient.js
+++ b/test/unit/helpers/mocks/AuthClient.js
@@ -1,11 +1,9 @@
-import Q from 'q';
-
 function addMethodSpy(mock, methodName) {
   const spy = jasmine.createSpy(methodName + 'Spy').and.callFake(function() {
     if (!mock.__nextRes) {
-      return Q.resolve({});
+      return Promise.resolve({});
     }
-    if (mock.__nextRes.isFulfilled() && mock.__globalSubscribeFn) {
+    if (!mock.__nextResIsError && mock.__globalSubscribeFn) {
       mock.__nextRes.then(function(res) {
         // Very specific to behavior in OktaAuth. Will remove when we remove
         // this logic
@@ -14,7 +12,7 @@ function addMethodSpy(mock, methodName) {
         }
         mock.__globalSubscribeFn(null, res);
       });
-    } else if (mock.__nextRes.isRejected() && mock.__globalSubscribeFn) {
+    } else if (mock.__nextResIsError && mock.__globalSubscribeFn) {
       mock.__nextRes.catch(function(err) {
         mock.__globalSubscribeFn(err, null);
       });
@@ -52,7 +50,8 @@ function Mock() {
 Mock.prototype.__setNextResponse = function(res) {
   const isError = res.responseJSON && res.responseJSON.errorCode;
 
-  this.__nextRes = isError ? Q.reject(res) : Q.resolve(res);
+  this.__nextResIsError = !!isError;
+  this.__nextRes = isError ? Promise.reject(res) : Promise.resolve(res);
 };
 
 Mock.prototype.__invokeResponse = function(res) {

--- a/test/unit/helpers/mocks/Util.js
+++ b/test/unit/helpers/mocks/Util.js
@@ -2,8 +2,9 @@
 import { _, $, Backbone, internal } from '@okta/courage';
 import Duo from '@okta/duo';
 import 'jasmine-ajax';
-import Q from 'q';
 import Bundles from 'util/Bundles';
+import { createDeferred } from 'util/createDeferred';
+import DelayUtil from 'util/delay';
 import keys from '../xhr/keys';
 import wellKnown from '../xhr/well-known';
 import wellKnownSharedResource from '../xhr/well-known-shared-resource';
@@ -162,17 +163,17 @@ fn.mockJqueryCss = function() {
 };
 
 fn.mockQDelay = function() {
-  const original = Q.delay;
+  const original = DelayUtil.delay;
 
-  spyOn(Q, 'delay').and.callFake(function() {
+  spyOn(DelayUtil, 'delay').and.callFake(function() {
     return original.call(this, 0);
   });
 };
 
 fn.mockRateLimiting = function() {
-  const deferred = Q.defer();
+  const deferred = createDeferred();
 
-  spyOn(Q, 'delay').and.callFake(function() {
+  spyOn(DelayUtil, 'delay').and.callFake(function() {
     return deferred.promise;
   });
   return deferred;

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -2,20 +2,62 @@ import { $, _ } from '@okta/courage';
 import config from 'config/config.json';
 import Util from 'helpers/mocks/Util';
 import 'jasmine-ajax';
-import Q from 'q';
 import $sandbox from 'sandbox';
 import Bundles from 'util/Bundles';
 import Logger from 'util/Logger';
+import { createDeferred } from 'util/createDeferred';
 import Dom from '../dom/Dom';
 
 const fn = {};
 const WAIT_MAX_TIME = 2000;
 const WAIT_INTERVAL = 20;
 
-const unhandledRejectionListener = function(event) {
-  // We've thrown an unexpected error in the test - setup a fake
-  // expectation to expose it to the developer
-  expect('Unhandled promise rejection').toEqual(event.reason);
+// Native replacement for Q's global unhandled-rejection tracking. jsdom
+// dispatches 'unhandledrejection' / 'rejectionhandled' on window; we collect
+// the reasons here so runTest() can assert a test left no rejection unhandled.
+let trackUnhandledRejections = true;
+let unhandledReasons = [];
+
+const onUnhandledRejection = function(event) {
+  // Always suppress the default handling so a stray rejection is never
+  // reported by the test runner itself (matching Q, which tracked rejections
+  // internally rather than letting them surface). Failures are surfaced via
+  // the assertion in runTest() - but only when tracking is enabled, so tests
+  // that intentionally leave a rejection (via stopUnhandledRejectionTracking)
+  // stay green.
+  if (event.preventDefault) {
+    event.preventDefault();
+  }
+  if (trackUnhandledRejections) {
+    unhandledReasons.push(event.reason);
+  }
+};
+
+const onRejectionHandled = function(event) {
+  // A previously-unhandled rejection that later gained a handler is no longer
+  // a failure - drop it from the collected reasons.
+  const idx = unhandledReasons.indexOf(event.reason);
+  if (idx !== -1) {
+    unhandledReasons.splice(idx, 1);
+  }
+};
+
+window.addEventListener('unhandledrejection', onUnhandledRejection);
+window.addEventListener('rejectionhandled', onRejectionHandled);
+
+// Clear collected reasons and (re)enable tracking. Called after every test;
+// also restores tracking for a test that turned it off (necessary in the case
+// of returning an api error response).
+fn.resetUnhandledRejections = function() {
+  unhandledReasons = [];
+  trackUnhandledRejections = true;
+};
+
+// Turn off unhandled-rejection tracking for tests that intentionally leave a
+// rejected promise (e.g. asserting an API error response).
+fn.stopUnhandledRejectionTracking = function() {
+  trackUnhandledRejections = false;
+  unhandledReasons = [];
 };
 
 function runTest(jasmineFn, desc, testFn) {
@@ -27,24 +69,15 @@ function runTest(jasmineFn, desc, testFn) {
     };
 
     window.addEventListener('error', errListener);
-    window.addEventListener('unhandledrejection', unhandledRejectionListener);
 
     return testFn.call(this).then(function() {
-      const unhandledFailures = Q.getUnhandledReasons();
-      if (unhandledFailures.length) {
+      if (unhandledReasons.length) {
         // eslint-disable-next-line no-console
-        console.error('Unhandled Q failures: ', unhandledFailures);
+        console.error('Unhandled promise rejections: ', unhandledReasons);
       }
-      expect(unhandledFailures).toEqual([]);
-      // Reset unhandled exceptions (which in the normal case come from the
-      // error tests we're running) so that this array does not get
-      // unreasonably large (and subsequently slow down our tests)
-      // Also, if a test turns off unhandled exceptions (necessary in the
-      // case of returning an api error response), this method will turn it
-      // back on.
-      Q.resetUnhandledRejections();
+      expect(unhandledReasons).toEqual([]);
+      fn.resetUnhandledRejections();
       window.removeEventListener('error', errListener);
-      window.removeEventListener('unhandledrejection', unhandledRejectionListener);
     });
   });
 }
@@ -107,7 +140,7 @@ fn.fitp = runTest.bind({}, fit);
  *             Instead use any of the Expect.wait* functions.
  */
 fn.tick = function(returnVal) {
-  const deferred = Q.defer();
+  const deferred = createDeferred();
 
   // Using four setTimeouts to remove flakiness (some tests need an extra
   // cycle when transitioning/setting up, and the new tick in OktaAuth makes
@@ -227,14 +260,22 @@ fn.waitForSecurityImageTooltip = function(expectToBeVisible, resolveValue) {
 fn.wait = function(condition, resolveValue, timeout) {
   function check(success, fail, triesLeft) {
     if (condition()) {
-      success(resolveValue);
+      // Resolve on a macrotask (not the immediate microtask) so any work the
+      // caller kicked off just before waiting - e.g. async XHRs - has a tick to
+      // run first. This matches the previous Q.Promise-based scheduling and
+      // keeps timing-sensitive tests stable.
+      setTimeout(function() {
+        success(resolveValue);
+      }, 0);
     } else if (triesLeft <= 0) {
-      fail(new Error('Wait condition not met'));
+      setTimeout(function() {
+        fail(new Error('Wait condition not met'));
+      }, 0);
     } else {
       setTimeout(check.bind(null, success, fail, triesLeft - 1), WAIT_INTERVAL);
     }
   }
-  return Q.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     const numTries = (timeout || WAIT_MAX_TIME) / WAIT_INTERVAL;
 
     check(resolve, reject, numTries);

--- a/test/unit/spec/OktaSignInV1Bootstrap_spec.js
+++ b/test/unit/spec/OktaSignInV1Bootstrap_spec.js
@@ -4,7 +4,6 @@ import Expect from 'helpers/util/Expect';
 import errorResponse from 'helpers/xhr/ERROR_invalid_token';
 import introspectResponse from 'helpers/xhr/UNAUTHENTICATED';
 import 'jasmine-ajax';
-import Q from 'q';
 import $sandbox from 'sandbox';
 import Logger from 'util/Logger';
 import Widget from 'exports/default';
@@ -34,9 +33,9 @@ describe('OktaSignIn v1 pipeline bootstrap ', function() {
     jest.spyOn(window.history, 'pushState').mockImplementation(() => { });
     jest.spyOn(signIn.authClient.tx, 'introspect').mockImplementation(function() {
       if (responseData.status !== 200) {
-        return Q.reject(responseData.response);
+        return Promise.reject(responseData.response);
       } else {
-        return Q({
+        return Promise.resolve({
           data: responseData.response,
         });
       }
@@ -91,7 +90,7 @@ describe('OktaSignIn v1 pipeline bootstrap ', function() {
         expect(signInButton.length).toBe(1);
         expect(signInButton.attr('type')).toEqual('submit');
         expect(signInButton.attr('id')).toEqual('okta-signin-submit');
-        Q.resetUnhandledRejections();
+        Expect.resetUnhandledRejections();
       });
     });
   });

--- a/test/unit/spec/v1/EnrollCall_spec.js
+++ b/test/unit/spec/v1/EnrollCall_spec.js
@@ -13,7 +13,6 @@ import resActivateError from 'helpers/xhr/MFA_ENROLL_ACTIVATE_errorActivate';
 import resEnrollInvalidPhoneError from 'helpers/xhr/MFA_ENROLL_ACTIVATE_invalid_phone';
 import resAllFactors from 'helpers/xhr/MFA_ENROLL_allFactors';
 import resExistingPhone from 'helpers/xhr/MFA_ENROLL_callFactor_existingPhone';
-import Q from 'q';
 import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
@@ -510,7 +509,7 @@ Expect.describe('EnrollCall', function() {
       const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return setupAndSendCodeFn()
         .then(function(test) {
-          Q.stopUnhandledRejectionTracking();
+          Expect.stopUnhandledRejectionTracking();
           test.setNextResponse(resActivateError);
           test.form.setCode(123);
           test.form.submit();

--- a/test/unit/spec/v1/EnrollPassword_spec.js
+++ b/test/unit/spec/v1/EnrollPassword_spec.js
@@ -8,7 +8,6 @@ import Expect from 'helpers/util/Expect';
 import resAllFactors from 'helpers/xhr/FACTOR_ENROLL_allFactors';
 import resError from 'helpers/xhr/FACTOR_ENROLL_password_error';
 import resSuccess from 'helpers/xhr/SUCCESS';
-import Q from 'q';
 import $sandbox from 'sandbox';
 import RouterUtil from 'v1/util/RouterUtil';
 import LoginUtil from 'util/Util';
@@ -172,7 +171,7 @@ Expect.describe('EnrollPassword', function() {
   itp('shows error if error response on enrollment', function() {
     return setup()
       .then(function(test) {
-        Q.stopUnhandledRejectionTracking();
+        Expect.stopUnhandledRejectionTracking();
         test.setNextResponse(resError);
         test.form.setPassword('somepassword');
         test.form.setConfirmPassword('somepassword');

--- a/test/unit/spec/v1/EnrollQuestions_spec.js
+++ b/test/unit/spec/v1/EnrollQuestions_spec.js
@@ -12,7 +12,6 @@ import resQuestions from 'helpers/xhr/MFA_ENROLL_question_questions';
 import resSuccess from 'helpers/xhr/SUCCESS';
 import labelsCountryJa from 'helpers/xhr/labels_country_ja';
 import labelsLoginJa from 'helpers/xhr/labels_login_ja';
-import Q from 'q';
 import $sandbox from 'sandbox';
 import BrowserFeatures from 'util/BrowserFeatures';
 import RouterUtil from 'v1/util/RouterUtil';
@@ -238,7 +237,7 @@ function testEnrollQuestion(allFactors, expectedStateToken) {
   itp('shows error if error response on enrollment', function() {
     return setup(allFactors)
       .then(function(test) {
-        Q.stopUnhandledRejectionTracking();
+        Expect.stopUnhandledRejectionTracking();
         test.setNextResponse(resError);
         test.form.setAnswer('the answer');
         test.form.submit();

--- a/test/unit/spec/v1/EnrollU2F_spec.js
+++ b/test/unit/spec/v1/EnrollU2F_spec.js
@@ -9,7 +9,6 @@ import resEnrollActivateU2F from 'helpers/xhr/MFA_ENROLL_ACTIVATE_u2f';
 import resU2F from 'helpers/xhr/MFA_ENROLL_U2F';
 import resAllFactors from 'helpers/xhr/MFA_ENROLL_allFactors';
 import resSuccess from 'helpers/xhr/SUCCESS';
-import Q from 'q';
 import $sandbox from 'sandbox';
 const itp = Expect.itp;
 const tick = Expect.tick;
@@ -70,7 +69,7 @@ Expect.describe('EnrollU2F', function() {
   }
 
   function setupU2fFails(errorCode) {
-    Q.stopUnhandledRejectionTracking();
+    Expect.stopUnhandledRejectionTracking();
     mockU2f();
     spyOn(window.u2f, 'register').and.callFake(function(appId, registerRequests, registeredKeys, callback) {
       callback({ errorCode: errorCode });

--- a/test/unit/spec/v1/EnrollWebauthn_spec.js
+++ b/test/unit/spec/v1/EnrollWebauthn_spec.js
@@ -10,7 +10,7 @@ import resEnrollActivateWebauthn from 'helpers/xhr/MFA_ENROLL_ACTIVATE_webauthn'
 import resAllFactors from 'helpers/xhr/MFA_ENROLL_allFactors';
 import resWebauthn from 'helpers/xhr/MFA_ENROLL_webauthn';
 import resSuccess from 'helpers/xhr/SUCCESS';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import $sandbox from 'sandbox';
 import BrowserFeatures from 'util/BrowserFeatures';
 import CryptoUtil from 'util/CryptoUtil';
@@ -88,7 +88,7 @@ Expect.describe('EnrollWebauthn', function() {
     mockWebauthn();
     spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
     spyOn(navigator.credentials, 'create').and.callFake(function() {
-      const deferred = Q.defer();
+      const deferred = createDeferred();
       var localTransports;
       var localClientExtensions;
       if (!isNullable) {
@@ -114,10 +114,10 @@ Expect.describe('EnrollWebauthn', function() {
   }
 
   function mockWebauthnFailureRegistration() {
-    Q.stopUnhandledRejectionTracking();
+    Expect.stopUnhandledRejectionTracking();
     mockWebauthn();
     spyOn(navigator.credentials, 'create').and.callFake(function() {
-      const deferred = Q.defer();
+      const deferred = createDeferred();
 
       deferred.reject({ message: 'something went wrong' });
       return deferred.promise;
@@ -128,7 +128,7 @@ Expect.describe('EnrollWebauthn', function() {
     mockWebauthn();
     spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
     spyOn(navigator.credentials, 'create').and.callFake(function() {
-      const deferred = Q.defer();
+      const deferred = createDeferred();
       const localTransports = transports;
       const localClientExtensions = clientExtensions;
 

--- a/test/unit/spec/v1/EnrollWindowsHello_spec.js
+++ b/test/unit/spec/v1/EnrollWindowsHello_spec.js
@@ -8,7 +8,7 @@ import Expect from 'helpers/util/Expect';
 import responseMfaEnrollActivateWindowsHello from 'helpers/xhr/MFA_ENROLL_ACTIVATE_windows_hello';
 import responseMfaEnrollAll from 'helpers/xhr/MFA_ENROLL_allFactors';
 import responseSuccess from 'helpers/xhr/SUCCESS';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 import webauthn from 'util/webauthn';
@@ -49,14 +49,14 @@ Expect.describe('EnrollWindowsHello', function() {
     spyOn(webauthn, 'isAvailable').and.returnValue(false);
     spyOn(webauthn, 'makeCredential');
     spyOn(webauthn, 'getAssertion');
-    return Q();
+    return Promise.resolve();
   }
 
   function emulateWindows(errorType) {
     spyOn(webauthn, 'isAvailable').and.returnValue(true);
 
     spyOn(webauthn, 'makeCredential').and.callFake(function() {
-      const deferred = Q.defer();
+      const deferred = createDeferred();
 
       switch (errorType) {
       case 'AbortError':
@@ -81,7 +81,7 @@ Expect.describe('EnrollWindowsHello', function() {
       return deferred.promise;
     });
 
-    return Q();
+    return Promise.resolve();
   }
 
   describe('Header & Footer', function() {

--- a/test/unit/spec/v1/ForgotPassword_spec.js
+++ b/test/unit/spec/v1/ForgotPassword_spec.js
@@ -13,7 +13,6 @@ import resChallengeEmail from 'helpers/xhr/RECOVERY_CHALLENGE_EMAIL_PWD';
 import resChallengeSms from 'helpers/xhr/RECOVERY_CHALLENGE_SMS_PWD';
 import resError from 'helpers/xhr/RECOVERY_error';
 import resSuccess from 'helpers/xhr/SUCCESS';
-import Q from 'q';
 import $sandbox from 'sandbox';
 const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
@@ -482,7 +481,7 @@ Expect.describe('ForgotPassword', function() {
       return setup()
         .then(function(test) {
           Util.resetAjaxRequests();
-          Q.stopUnhandledRejectionTracking();
+          Expect.stopUnhandledRejectionTracking();
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.sendEmail();

--- a/test/unit/spec/v1/IDPDiscovery_spec.js
+++ b/test/unit/spec/v1/IDPDiscovery_spec.js
@@ -19,7 +19,7 @@ import resErrorUnauthorized from 'helpers/xhr/UNAUTHORIZED_ERROR';
 import resSecurityImage from 'helpers/xhr/security_image';
 import resSecurityImageFail from 'helpers/xhr/security_image_fail';
 import IDPDiscovery from 'v1/models/IDPDiscovery';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import $sandbox from 'sandbox';
 import BrowserFeatures from 'util/BrowserFeatures';
 import DeviceFingerprint from 'v1/util/DeviceFingerprint';
@@ -58,7 +58,7 @@ function setup(settings, requests) {
 
   const setNextWebfingerResponse = function(res, reject) {
     spyOn(authClient, 'webfinger').and.callFake(function() {
-      const deferred = Q.defer();
+      const deferred = createDeferred();
 
       if (reject) {
         deferred.reject(res);
@@ -751,7 +751,7 @@ Expect.describe('IDPDiscovery', function() {
         is true (useDeviceFingerprintForSecurityImage defaults to true)`,
       function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
@@ -776,7 +776,7 @@ Expect.describe('IDPDiscovery', function() {
         deviceFingerprinting and useDeviceFingerprintForSecurityImage) are enabled`,
       function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
@@ -867,7 +867,7 @@ Expect.describe('IDPDiscovery', function() {
     itp('renders primary auth with a device fingerprint for passwordless flow during idp discovery',
       function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
         });
@@ -890,7 +890,7 @@ Expect.describe('IDPDiscovery', function() {
     itp('renders primary auth with a device fingerprint when passwordless is disabled during idp discovery',
       function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
         });
@@ -919,7 +919,7 @@ Expect.describe('IDPDiscovery', function() {
     itp('renders primary auth when device fingerprint generation fails',
       function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
           deferred.reject('testFailure');
           return deferred.promise;
         });
@@ -957,15 +957,13 @@ Expect.describe('IDPDiscovery', function() {
             spyOn(test.securityBeacon, 'toggleClass').and.callThrough();
             test.setNextWebfingerResponse(resSuccessSAML);
             test.form.submit();
-            return Expect.waitForSpyCall(test.securityBeacon.toggleClass, test);
-          })
-          .then(test => {
-            expect(test.securityBeacon.toggleClass).toHaveBeenCalledWith(BEACON_LOADING_CLS, true);
-            test.securityBeacon.toggleClass.calls.reset();
-            return waitForWebfingerCall(test);
+            return Expect.waitForSpyCall(SharedUtil.redirect, test);
           })
           .then(function(test) {
-            expect(test.securityBeacon.toggleClass).toHaveBeenCalledWith(BEACON_LOADING_CLS, false);
+            const spyCalls = test.securityBeacon.toggleClass.calls;
+
+            expect(spyCalls.argsFor(0)).toEqual([BEACON_LOADING_CLS, true]);
+            expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
           });
       });
       itp('does not show beacon-loading animation when authClient webfinger fails', function() {
@@ -977,7 +975,7 @@ Expect.describe('IDPDiscovery', function() {
             return waitForBeaconChange(test);
           })
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             spyOn(test.securityBeacon, 'toggleClass');
             test.setNextWebfingerResponse(resError, true);
             test.form.submit();
@@ -1006,7 +1004,7 @@ Expect.describe('IDPDiscovery', function() {
       itp('does not show beacon-loading animation when webfinger fails (no security image)', function() {
         return setup()
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             test.setNextWebfingerResponse(resError, true);
             test.form.setUsername('testuser@clouditude.net');
             test.form.submit();

--- a/test/unit/spec/v1/LoginRouter_spec.js
+++ b/test/unit/spec/v1/LoginRouter_spec.js
@@ -32,7 +32,6 @@ import resUnauthenticated from 'helpers/xhr/UNAUTHENTICATED';
 import labelsCountryJa from 'helpers/xhr/labels_country_ja';
 import labelsLoginJa from 'helpers/xhr/labels_login_ja';
 import resWellKnownSR from 'helpers/xhr/well-known-shared-resource';
-import Q from 'q';
 import $sandbox from 'sandbox';
 import BrowserFeatures from 'util/BrowserFeatures';
 import Bundles from 'util/Bundles';
@@ -118,7 +117,7 @@ Expect.describe('v1/LoginRouter', function() {
     }
     setNextResponse(resp);
 
-    return Q({
+    return Promise.resolve({
       router: router,
       ac: authClient,
       setNextResponse: setNextResponse,

--- a/test/unit/spec/v1/MfaVerify_spec.js
+++ b/test/unit/spec/v1/MfaVerify_spec.js
@@ -44,7 +44,7 @@ import resRSAChangePin from 'helpers/xhr/RSA_ERROR_change_pin';
 import resSuccess from 'helpers/xhr/SUCCESS';
 import labelsCountryJa from 'helpers/xhr/labels_country_ja';
 import labelsLoginJa from 'helpers/xhr/labels_login_ja';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import $sandbox from 'sandbox';
 import BrowserFeatures from 'util/BrowserFeatures';
 import RouterUtil from 'v1/util/RouterUtil';
@@ -187,7 +187,7 @@ Expect.describe('MFA Verify', function() {
         await Expect.waitForVerifyCustomFactor();
       } else {
         router.verify(selectedFactor.get('provider'), selectedFactor.get('factorType'));
-        // BaseLoginController returns an instance of Q() from `fetchInitialData`
+        // BaseLoginController returns a native Promise from `fetchInitialData`
         // use tick() to wait for this promise to resolve and render
         await tick();
         await Expect.waitForMfaVerify();
@@ -238,7 +238,7 @@ Expect.describe('MFA Verify', function() {
       const factorType = selectedFactor.get('factorType');
 
       router.verifyNoProvider(factorType);
-      // BaseLoginController returns an instance of Q() from `fetchInitialData`
+      // BaseLoginController returns a native Promise from `fetchInitialData`
       // use tick() to wait for this promise to resolve and render
       await tick();
       await Expect.waitForMfaVerify();
@@ -450,7 +450,7 @@ Expect.describe('MFA Verify', function() {
     }
     test.setNextResponse(responses);
     test.router.verifyU2F();
-    // BaseLoginController returns an instance of Q() from `fetchInitialData`
+    // BaseLoginController returns a native Promise from `fetchInitialData`
     // use tick() to wait for this promise to resolve and render
     await tick();
     await Expect.waitForVerifyU2F();
@@ -595,49 +595,37 @@ Expect.describe('MFA Verify', function() {
     spyOn(webauthn, 'isAvailable').and.returnValue(false);
     spyOn(webauthn, 'makeCredential');
     spyOn(webauthn, 'getAssertion');
-    return Q();
+    return Promise.resolve();
   }
 
   function emulateWindows(errorType) {
     if (errorType) {
-      Q.stopUnhandledRejectionTracking();
+      Expect.stopUnhandledRejectionTracking();
     }
     spyOn(webauthn, 'isAvailable').and.returnValue(true);
 
     spyOn(webauthn, 'getAssertion').and.callFake(function() {
-      const deferred = Q.defer();
-
       switch (errorType) {
       case 'AbortError':
-        deferred.reject({
-          message: 'AbortError',
-        });
-        break;
-
       case 'NotSupportedError':
-        deferred.reject({
-          message: 'NotSupportedError',
-        });
-        break;
-
       case 'NotFoundError':
-        deferred.reject({
-          message: 'NotFoundError',
+        // Defer the rejection into the returned chain so the rejected promise
+        // is never left unhandled across ticks - native promises (unlike Q)
+        // surface that as an unhandled rejection.
+        return tick().then(function() {
+          return Promise.reject({ message: errorType });
         });
-        break;
 
       default:
-        deferred.resolve({
+        return tick({
           authenticatorData: 'authenticatorData1234',
           clientData: 'clientData1234',
           signature: 'signature1234',
         });
       }
-
-      return tick(deferred.promise);
     });
 
-    return Q();
+    return Promise.resolve();
   }
 
   // Mocks the right calls for Auth SDK's transactions handled in the widget
@@ -3242,7 +3230,7 @@ Expect.describe('MFA Verify', function() {
                 }, test);
               })
               .then(function(test) {
-                const deferred = Q.defer();
+                const deferred = createDeferred();
 
                 expect(test.router.controller.model.appState.get('transaction').status).toBe('MFA_CHALLENGE');
                 const transaction = test.router.controller.model.appState.get('transaction');
@@ -3523,7 +3511,7 @@ Expect.describe('MFA Verify', function() {
             }
             return setupOktaPushWithIntrospect().then(function(test) {
               spyOn(test.router.settings, 'callGlobalError');
-              Q.stopUnhandledRejectionTracking();
+              Expect.stopUnhandledRejectionTracking();
               return (setupFailurePolling(test)
               // Final response - failed
                 .then(function(test) {
@@ -3596,7 +3584,7 @@ Expect.describe('MFA Verify', function() {
             }
             return setupOktaPushWithIntrospect().then(function(test) {
               spyOn(test.router.settings, 'callGlobalError');
-              Q.stopUnhandledRejectionTracking();
+              Expect.stopUnhandledRejectionTracking();
               return setupFailurePolling(test)
                 .then(function(test) {
                   expect(test.form.submitButton().prop('disabled')).toBe(true);
@@ -3767,7 +3755,7 @@ Expect.describe('MFA Verify', function() {
               const form = test.form[1];
 
               form.inlineTOTPAdd().click();
-              Q.stopUnhandledRejectionTracking();
+              Expect.stopUnhandledRejectionTracking();
               test.setNextResponse(resInvalidTotp);
               form.setAnswer('wrong');
               form.inlineTOTPVerify().click();
@@ -3803,7 +3791,7 @@ Expect.describe('MFA Verify', function() {
               const form = test.form[1];
 
               form.inlineTOTPAdd().click();
-              Q.stopUnhandledRejectionTracking();
+              Expect.stopUnhandledRejectionTracking();
               test.setNextResponse(resInvalidTotp);
               form.setAnswer('wrong');
               form.inlineTOTPVerify().click();
@@ -3849,7 +3837,7 @@ Expect.describe('MFA Verify', function() {
           return setupOktaPushWithTOTP()
             .then(function(test) {
               mockTransactions(test.router.controller, true);
-              Q.stopUnhandledRejectionTracking();
+              Expect.stopUnhandledRejectionTracking();
               test.setNextResponse(resInvalidTotp);
               const form = test.form[1];
 

--- a/test/unit/spec/v1/PasswordReset_spec.js
+++ b/test/unit/spec/v1/PasswordReset_spec.js
@@ -11,7 +11,6 @@ import resError from 'helpers/xhr/PASSWORD_RESET_error';
 import resErrorNoCause from 'helpers/xhr/PASSWORD_RESET_error_noCause';
 import resPasswordResetWithComplexity from 'helpers/xhr/PASSWORD_RESET_withComplexity';
 import resSuccess from 'helpers/xhr/SUCCESS';
-import Q from 'q';
 import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const SharedUtil = internal.util.Util;
@@ -834,7 +833,7 @@ Expect.describe('PasswordReset', function() {
   itp('shows an error msg if there is an error submitting', function() {
     return setup()
       .then(function(test) {
-        Q.stopUnhandledRejectionTracking();
+        Expect.stopUnhandledRejectionTracking();
         test.setNextResponse(resError);
         test.form.setNewPassword('a');
         test.form.setConfirmPassword('a');
@@ -882,7 +881,7 @@ Expect.describe('PasswordReset', function() {
   itp('shows a simpler error msg without requirements if there is an error submitting', function() {
     return setup({ policyComplexity: 'all', 'features.showPasswordRequirementsAsHtmlList': true })
       .then(function(test) {
-        Q.stopUnhandledRejectionTracking();
+        Expect.stopUnhandledRejectionTracking();
         test.setNextResponse(resError);
         test.form.setNewPassword('a');
         test.form.setConfirmPassword('a');
@@ -926,7 +925,7 @@ Expect.describe('PasswordReset', function() {
   itp('shows error summary if error cause is missing, if there is an error submitting', function() {
     return setup({ policyComplexity: 'all', 'features.showPasswordRequirementsAsHtmlList': true })
       .then(function(test) {
-        Q.stopUnhandledRejectionTracking();
+        Expect.stopUnhandledRejectionTracking();
         test.setNextResponse(resErrorNoCause);
         test.form.setNewPassword('a');
         test.form.setConfirmPassword('a');

--- a/test/unit/spec/v1/PrimaryAuth_spec.js
+++ b/test/unit/spec/v1/PrimaryAuth_spec.js
@@ -25,7 +25,7 @@ import resSecurityImage from 'helpers/xhr/security_image';
 import resSecurityImageFail from 'helpers/xhr/security_image_fail';
 import resSecurityImageError from 'helpers/xhr/security_image_error';
 import PrimaryAuth from 'v1/models/PrimaryAuth';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import $sandbox from 'sandbox';
 import BrowserFeatures from 'util/BrowserFeatures';
 import DeviceFingerprint from 'v1/util/DeviceFingerprint';
@@ -192,7 +192,7 @@ function setupUnauthenticated(settings, requests) {
 function setupPasswordlessAuth(requests, refreshState) {
   return setup({ 'features.passwordlessAuth': true }, requests, refreshState).then(function(test) {
     test.setNextResponse(resPasswordlessUnauthenticated);
-    return Q(test);
+    return Promise.resolve(test);
   });
 }
 
@@ -1205,7 +1205,7 @@ Expect.describe('PrimaryAuth', function() {
         is true (useDeviceFingerprintForSecurityImage defaults to true)`,
       function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
@@ -1229,7 +1229,7 @@ Expect.describe('PrimaryAuth', function() {
         deviceFingerprinting and useDeviceFingerprintForSecurityImage) are enabled`,
       function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
@@ -1319,7 +1319,7 @@ Expect.describe('PrimaryAuth', function() {
     });
     itp('contains device fingerprint header in primaryAuth if feature is enabled', function() {
       spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-        const deferred = Q.defer();
+        const deferred = createDeferred();
 
         deferred.resolve('thisIsTheDeviceFingerprint');
         return deferred.promise;
@@ -1343,7 +1343,7 @@ Expect.describe('PrimaryAuth', function() {
     });
     itp('continues with primary auth if there is an error getting fingerprint when feature is enabled', function() {
       spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-        const deferred = Q.defer();
+        const deferred = createDeferred();
 
         deferred.reject('there was an error');
         return deferred.promise;
@@ -1380,7 +1380,7 @@ Expect.describe('PrimaryAuth', function() {
       'contains device fingerprint and typing pattern header in primaryAuth if both features are enabled',
       function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
@@ -1412,7 +1412,7 @@ Expect.describe('PrimaryAuth', function() {
     );
     itp('does not load deviceFingerprint when username field looses focus if username is empty', function() {
       spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-        const deferred = Q.defer();
+        const deferred = createDeferred();
 
         deferred.resolve('thisIsTheDeviceFingerprint');
         return deferred.promise;
@@ -1426,7 +1426,7 @@ Expect.describe('PrimaryAuth', function() {
     });
     itp('disables the "sign in" button while fetching fingerprint before model.save', function() {
       spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-        const deferred = Q.defer();
+        const deferred = createDeferred();
 
         deferred.resolve('thisIsTheDeviceFingerprint');
         return deferred.promise;
@@ -1497,7 +1497,7 @@ Expect.describe('PrimaryAuth', function() {
       });
       itp('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
+          const deferred = createDeferred();
   
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
@@ -1537,7 +1537,7 @@ Expect.describe('PrimaryAuth', function() {
             return setUsernameAndWaitForBeaconChange(test, 'testuser');
           })
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             spyOn(test.securityBeacon, 'toggleClass');
             test.setNextResponse(resUnauthorized);
             test.form.setPassword('pass');
@@ -1559,7 +1559,7 @@ Expect.describe('PrimaryAuth', function() {
             return setUsernameAndWaitForBeaconChange(test, 'testuser');
           })
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             spyOn(test.securityBeacon, 'toggleClass');
             test.setNextResponse(resPwdExpired);
             test.form.setPassword('pass');
@@ -1580,7 +1580,7 @@ Expect.describe('PrimaryAuth', function() {
             return setUsernameAndWaitForBeaconChange(test, 'testuser');
           })
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             spyOn(test.securityBeacon, 'toggleClass');
             spyOn(test.router.settings, 'callGlobalError');
             test.setNextResponse({ status: 0, response: {} });
@@ -1611,7 +1611,7 @@ Expect.describe('PrimaryAuth', function() {
       itp('does not show beacon-loading animation when primaryAuth fails (no security image)', function() {
         return setup()
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             test.setNextResponse(resUnauthorized);
             test.form.setUsername('testuser');
             test.form.setPassword('pass');
@@ -1626,7 +1626,7 @@ Expect.describe('PrimaryAuth', function() {
       itp('does not show beacon-loading animation when password expires (no security image)', function() {
         return setup()
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             test.setNextResponse(resPwdExpired);
             test.form.setUsername('testuser');
             test.form.setPassword('pass');
@@ -1641,7 +1641,7 @@ Expect.describe('PrimaryAuth', function() {
       it('hides beacon-loading animation when user lockout message is displayed(no security image and selfServiceUnlock is off)', function() {
         return setup()
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             test.setNextResponse(resLockedOut);
             test.form.setUsername('testuser');
             test.form.setPassword('pass');
@@ -1658,7 +1658,7 @@ Expect.describe('PrimaryAuth', function() {
       itp('hide beacon spinner when security image is disabled during invalid login attempt', function() {
         return setup()
           .then(function(test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             test.setNextResponse(resUnauthorized);
             test.form.setUsername('testuser');
             test.form.setPassword('pass');
@@ -1676,7 +1676,7 @@ Expect.describe('PrimaryAuth', function() {
         return setup()
           .then(function(test) {
             spyOn(test.router.settings, 'callGlobalError');
-            Q.stopUnhandledRejectionTracking();
+            Expect.stopUnhandledRejectionTracking();
             test.setNextResponse({ status: 0, response: {} });
             test.form.setUsername('testuser');
             test.form.setPassword('pass');
@@ -1711,7 +1711,7 @@ Expect.describe('PrimaryAuth', function() {
     });
     itp('shows beacon-loading animation while loading security image (with deviceFingerprint)', function() {
       spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-        const deferred = Q.defer();
+        const deferred = createDeferred();
 
         deferred.resolve('thisIsTheDeviceFingerprint');
         return deferred.promise;

--- a/test/unit/spec/v1/RecoveryLoading_spec.js
+++ b/test/unit/spec/v1/RecoveryLoading_spec.js
@@ -9,7 +9,6 @@ import Util from 'helpers/mocks/Util';
 import Expect from 'helpers/util/Expect';
 import resRecovery from 'helpers/xhr/RECOVERY';
 import resError from 'helpers/xhr/RECOVERY_EXPIRED_error';
-import Q from 'q';
 import $sandbox from 'sandbox';
 const itp = Expect.itp;
 
@@ -57,7 +56,7 @@ function setup(settings, callRecoveryLoading, fail = false) {
   // shall not resolve / wait for anything that may cause promise.resolve,
   // which will end the test.
   // @see Expect.runTest
-  return Q(testData);
+  return Promise.resolve(testData);
 }
 
 Expect.describe('Recovery Loading', function() {

--- a/test/unit/spec/v1/RefreshAuthState_spec.js
+++ b/test/unit/spec/v1/RefreshAuthState_spec.js
@@ -6,7 +6,6 @@ import FormView from 'helpers/dom/Form';
 import Util from 'helpers/mocks/Util';
 import Expect from 'helpers/util/Expect';
 import resEnroll from 'helpers/xhr/MFA_ENROLL_allFactors';
-import Q from 'q';
 import $sandbox from 'sandbox';
 const itp = Expect.itp;
 
@@ -35,7 +34,7 @@ function setup(settings) {
   Util.registerRouter(router);
   Util.mockRouterNavigate(router);
   Util.mockJqueryCss();
-  return Q({
+  return Promise.resolve({
     router: router,
     beacon: beacon,
     form: form,

--- a/test/unit/spec/v1/VerifyWebauthn_spec.js
+++ b/test/unit/spec/v1/VerifyWebauthn_spec.js
@@ -14,7 +14,7 @@ import resAllFactors from 'helpers/xhr/MFA_REQUIRED_allFactors';
 import resMultipleWebauthn from 'helpers/xhr/MFA_REQUIRED_multipleWebauthn';
 import resMultipleWebauthnWithQuestion from 'helpers/xhr/MFA_REQUIRED_multipleWebauthn_question';
 import resSuccess from 'helpers/xhr/SUCCESS';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import $sandbox from 'sandbox';
 import CryptoUtil from 'util/CryptoUtil';
 import BrowserFeatures from 'util/BrowserFeatures';
@@ -150,7 +150,7 @@ function mockWebauthn(options) {
 
 function mockWebauthnSignFailure() {
   spyOn(navigator.credentials, 'get').and.callFake(function() {
-    const deferred = Q.defer();
+    const deferred = createDeferred();
 
     deferred.reject({ message: 'something went wrong' });
     return deferred.promise;
@@ -163,7 +163,7 @@ function mockWebauthnSignSuccess(rememberDevice) {
       $('[name=rememberDevice]').prop('checked', true);
       $('[name=rememberDevice]').trigger('change');
     }
-    const deferred = Q.defer();
+    const deferred = createDeferred();
 
     deferred.resolve({
       response: {
@@ -177,7 +177,7 @@ function mockWebauthnSignSuccess(rememberDevice) {
 }
 
 function mockWebauthnSignPending() {
-  spyOn(navigator.credentials, 'get').and.returnValue(Q.defer().promise);
+  spyOn(navigator.credentials, 'get').and.returnValue(createDeferred().promise);
 }
 
 function setupWebauthnFactor(options) {

--- a/test/unit/spec/webauthn_spec.js
+++ b/test/unit/spec/webauthn_spec.js
@@ -1,12 +1,12 @@
 import Expect from 'helpers/util/Expect';
-import Q from 'q';
+import { createDeferred } from 'util/createDeferred';
 import webauthn from 'util/webauthn';
 
 Expect.describe('webauthn', function() {
   function setupMsCredentials() {
     window.msCredentials = {
       makeCredential: function() /*accountInfo, cryptoParams, challenge*/ {
-        const result = Q.defer();
+        const result = createDeferred();
 
         result.resolve({
           id: 'msCredentials_ID',
@@ -18,7 +18,7 @@ Expect.describe('webauthn', function() {
       },
 
       getAssertion: function() /*challenge, filters*/ {
-        const result = Q.defer();
+        const result = createDeferred();
 
         result.resolve({
           id: 'msCredentials_ID',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5719,11 +5719,6 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.15.tgz#e6e5a86d602beaca71ce5163fadf5f95d70931c7"
   integrity sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==
 
-"@types/q@^1.5.5":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
-  integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
-
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -17944,11 +17939,6 @@ pvutils@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
   integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
-
-q@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
-  integrity sha512-/CdEdaw49VZVmyIDGUQKDDT53c7qBkO6g5CefWz91Ae+l4+cRtcDYwMTXh6me4O8TMldeGHG3N2Bl84V78Ywbg==
 
 qrcode-terminal@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Resolves: OKTA-1236137

## Description:
Q is not needed anymore because
* We will use native Promise in modern browsers
* We already polyfill Promise for IE

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1236137](https://oktainc.atlassian.net/browse/OKTA-1236137)

### Reviewers:

### Screenshot/Video:

### Downstream Monolith Build:
Gen2 downstream with Selenium test: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=OKTA-1236137-lx-siw-selenium-test&page=1&pageSize=6&sha=1ced81d2d28b36e593d3ead38f66836fbcfd60bc&tab=main (one failure, not related with this change)

Gen3 nightly: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=SIWv3-builder-OKTA-1236137-lx-siw-selenium-test-1ced81d2d28b36e593d3ead38f66836fbcfd60bc&page=1&pageSize=6&tab=main

Cross browser (IE11): https://bacon-go.aue1e.saasure.net/tasks/CB_MULTI_BS?taskId=ecce82d5dc9446f6beeff1097113a2d1


