### PR TITLE
fix(a11y): clear stale banner message on step change (OKTA-1227830)

### DIFF
--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
@@ -14,6 +14,7 @@ import { IdxContext, IdxStatus, IdxTransaction } from '@okta/okta-auth-js';
 import { act } from '@testing-library/preact';
 import {
   FormBag,
+  IWidgetContext,
   LinkElement,
   TitleElement,
   WidgetProps,
@@ -410,5 +411,38 @@ describe('Terminal Transaction Transformer Tests', () => {
     transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(redirectTransformer).toHaveBeenCalled();
+  });
+
+  // OKTA-1227830: the OAuth2 "Back to sign in" re-bootstraps in place (no reload) and does not
+  // go through useOnSubmit, so it must clear any prior banner itself to avoid a stale message
+  // being re-announced by screen readers on the sign-in view.
+  it('should clear the banner message when Back to sign in is clicked in the OAuth2 bootstrap flow', async () => {
+    mockBootstrapFn.mockClear();
+    mockAuthClient = {
+      transactionManager: { clear: jest.fn() },
+      options: { recoveryToken: 'some-recovery-token' },
+    };
+    widgetProps = {
+      clientId: 'abcd1234',
+      authScheme: 'oauth2',
+      authClient: mockAuthClient,
+    } as WidgetProps;
+    transaction.messages?.push(getMockMessage('Some error', 'ERROR', 'some.generic.error'));
+
+    const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
+
+    const cancelLink = formBag.uischema.elements.find(
+      (el) => el.type === 'Link' && (el as LinkElement).options?.dataSe === 'cancel',
+    ) as LinkElement;
+    // Uses an in-place onClick (bootstrap), not an href navigation
+    expect(typeof cancelLink.options?.onClick).toBe('function');
+    expect(cancelLink.options?.href).toBeUndefined();
+
+    const setMessage = jest.fn();
+    await cancelLink.options?.onClick?.({ setMessage } as unknown as IWidgetContext);
+
+    expect(setMessage).toHaveBeenCalledWith(undefined);
+    expect(mockAuthClient.transactionManager.clear).toHaveBeenCalledTimes(1);
+    expect(mockBootstrapFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -24,6 +24,7 @@ import {
 } from '../../constants';
 import {
   FormBag,
+  IWidgetContext,
   LinkElement,
   TitleElement,
   UISchemaLayout,
@@ -138,7 +139,12 @@ const appendViewLinks = (
         window.location.assign(window.location.href);
       };
     } else if (isOauth2Enabled(widgetProps)) {
-      cancelLink.options.onClick = async () => {
+      cancelLink.options.onClick = async (widgetContext?: IWidgetContext) => {
+        // OKTA-1227830: This is the only "Back to sign in" path that re-bootstraps in place
+        // (no page reload) without going through useOnSubmit, so clear any prior banner here.
+        // Otherwise a stale message (e.g. a "Forgot password" error) can linger in the form's
+        // aria-live region and be re-announced by screen readers on the sign-in view.
+        widgetContext?.setMessage(undefined);
         authClient?.transactionManager.clear();
         // We have to directly delete the recoveryToken since it is set once upon authClient instantiation
         delete authClient?.options.recoveryToken;


### PR DESCRIPTION
A banner message set on one step (e.g. a "Forgot password" error) could survive into a later view and be re-announced by screen readers via the form's aria-live region — e.g. after returning to the sign-in form and submitting again.

Clear `message` in the same batch as the transaction update on the bootstrap, resume, and polling paths (which previously did not clear it), plus a catch-all effect that clears on any step change for non-client transactions. The form-level aria-live region is left intact so the loading-state announcement from OKTA-673876 is preserved.

Co-Authored-By: Claude Code

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



