### PR TITLE
fix: OKTA-1250822 NFC sign-in hangs on 2nd attempt (CUSTOM_URI)

### DIFF
--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.test.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.test.tsx
@@ -18,6 +18,11 @@ import LaunchAuthenticatorButton from './index';
 
 const mockFocusRef = createRef();
 const mockOnSubmit = jest.fn();
+const mockRedirectWithFormGet = jest.fn();
+
+jest.mock('../../../../util/Util', () => ({
+  redirectWithFormGet: (...args: unknown[]) => mockRedirectWithFormGet(...args),
+}));
 
 jest.mock('src/hooks', () => ({
   useOnSubmit: () => mockOnSubmit,
@@ -34,13 +39,13 @@ jest.mock('src/contexts', () => ({
 }));
 
 describe('LaunchAuthenticatorButton', () => {
-  const buildUischema = (step: string) => ({
+  const buildUischema = (step: string, extraOptions: Record<string, unknown> = {}) => ({
     translations: [
       { name: 'label', value: 'Sign in with NFC' },
       { name: 'icon-description', value: 'Launch authenticator icon' },
     ],
     focus: true,
-    options: { step },
+    options: { step, ...extraOptions },
   });
 
   afterEach(() => {
@@ -108,5 +113,57 @@ describe('LaunchAuthenticatorButton', () => {
       isActionStep: false,
       params: { rememberMe: undefined },
     });
+  });
+
+  // OKTA-1250822: NFC must not fire the (stale) launch-screen deep link on click; the
+  // challenge-poll screen fires the correct challenge.
+  it('does NOT fire a device-challenge deep link on click for the NFC launch step', () => {
+    const assignMock = jest.fn();
+    jest.spyOn(global, 'location', 'get').mockReturnValue({
+      href: 'http://localhost:3000',
+      assign: assignMock,
+    } as unknown as Location);
+
+    render(
+      <LaunchAuthenticatorButton
+        uischema={buildUischema(IDX_STEP.LAUNCH_NFC_AUTHENTICATOR, {
+          deviceChallengeUrl: 'https://example.okta.com/challenge?x=1',
+          challengeMethod: 'CUSTOM_URI',
+        }) as any}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in with nfc/i }));
+
+    expect(assignMock).not.toHaveBeenCalled();
+    expect(mockRedirectWithFormGet).not.toHaveBeenCalled();
+    // still submits the launch action
+    expect(mockOnSubmit).toHaveBeenCalledWith({
+      step: IDX_STEP.LAUNCH_NFC_AUTHENTICATOR,
+      isActionStep: false,
+      params: { rememberMe: undefined },
+    });
+  });
+
+  it('still fires the deep link on click for a non-NFC launch step', () => {
+    const assignMock = jest.fn();
+    jest.spyOn(global, 'location', 'get').mockReturnValue({
+      href: 'http://localhost:3000',
+      assign: assignMock,
+    } as unknown as Location);
+
+    render(
+      <LaunchAuthenticatorButton
+        uischema={buildUischema(IDX_STEP.LAUNCH_AUTHENTICATOR, {
+          deviceChallengeUrl: 'https://example.okta.com/challenge?x=1',
+          challengeMethod: 'CUSTOM_URI',
+        }) as any}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in with nfc/i }));
+
+    expect(assignMock).toHaveBeenCalledWith(expect.stringContaining('example.okta.com'));
+    expect(mockOnSubmit).toHaveBeenCalled();
   });
 });

--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -50,12 +50,17 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
     widgetProps,
   } = useWidgetContext();
 
+  const isNfc = step === IDX_STEP.LAUNCH_NFC_AUTHENTICATOR;
+
   const handleClick: ClickHandler = async () => {
     if (data.identifier) {
       // set loginHint in widget context to the current Username input field data
       setloginHint(data.identifier as string);
     }
-    if (deviceChallengeUrl) {
+    // OKTA-1250822: NFC must not fire the launch-screen challenge here — it's a stale challenge
+    // vs. the one the server mints at nfc/launch and polls for. The challenge-poll screen fires
+    // the correct one (matches v2's SignInWithNfcView, which fires no deep link on click).
+    if (deviceChallengeUrl && !isNfc) {
       const loginHintQueryParam = loginHint ? { login_hint: loginHint } : undefined;
       const urlObj = new URL(deviceChallengeUrl, getBaseUrl(widgetProps));
       if (isAndroid() && challengeMethod !== CHALLENGE_METHOD.APP_LINK) {
@@ -79,7 +84,6 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
 
   // The NFC launch button reuses this component, so pick the matching icon by step
   // instead of always showing the Okta Verify icon.
-  const isNfc = step === IDX_STEP.LAUNCH_NFC_AUTHENTICATOR;
   const StartIcon = isNfc ? NfcPinIcon : OktaVerifyIcon;
   const startIconName = isNfc ? 'mfa-nfc-pin' : 'mfa-okta-verify';
 


### PR DESCRIPTION
The NFC "Sign in with NFC" launch button fired the launch-screen deep link (context.authenticatorChallenge) on click. That is a different, soon-to-be-stale challenge than the one the server mints at /authenticators/nfc/launch and then polls for. On a CUSTOM_URI attempt, Okta Verify answered the stale challenge while the server waited on the fresh one, so the widget polled forever and never advanced.

Guard the deep-link firing so it is skipped for the NFC launch step; the challenge-poll screen fires the correct challenge. Non-NFC (OV FastPass) launch is unchanged. Matches v2's SignInWithNfcView, which fires no deep link on click.

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



