### PR TITLE
fix: OKTA-1259375 NFC PIN reset header - Gen2

### DIFF
--- a/src/v2/view-builder/views/nfcPin/EnrollNfcPinView.js
+++ b/src/v2/view-builder/views/nfcPin/EnrollNfcPinView.js
@@ -5,7 +5,7 @@ import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import { getFactorPageCustomLink, getSwitchAuthenticatorLink } from '../../utils/LinksUtil';
 import { doChallenge } from '../../utils/ChallengeViewUtil';
 import { AUTHENTICATOR_CANCEL_ACTION } from '../../utils/Constants';
-import { generatePasswordPolicyHtml } from '../password/PasswordPolicyUtil';
+import { generatePinPolicyHtml } from './PinPolicyUtil';
 
 /**
  * Phase 1: Device challenge — launches OV via setupNfcUrl, polls
@@ -56,7 +56,7 @@ const PinCreateBody = BaseForm.extend({
       || this.options.appState.get('enrollmentAuthenticator')?.settings;
     if (settings?.minLength) {
       const rulesList = [loc('oie.enroll.nfc_pin.create.requirement.length', 'login', [settings.minLength])];
-      generatePasswordPolicyHtml(this, rulesList, true);
+      generatePinPolicyHtml(this, rulesList, true);
     }
   },
 

--- a/src/v2/view-builder/views/nfcPin/PinPolicyUtil.js
+++ b/src/v2/view-builder/views/nfcPin/PinPolicyUtil.js
@@ -1,0 +1,29 @@
+import { View } from '@okta/courage';
+import hbs from '@okta/handlebars-inline-precompile';
+
+const generatePinPolicyHtml = function(form, rulesList, prepend) {
+  form.add(
+    View.extend({
+      tagName: 'section',
+      template:
+        hbs`<div class="password-authenticator--heading">
+        {{i18n code="oie.enroll.nfc_pin.create.requirements.header" bundle="login"}}
+      </div>
+      <ul class="password-authenticator--list">
+        {{#each rulesList}}<li>{{this}}</li>{{/each}}
+      </ul>`,
+      getTemplateData: () => ({ rulesList }),
+      attributes: {
+        'data-se': 'password-authenticator--rules'
+      }
+    }),
+    {
+      prepend,
+      selector: '.o-form-fieldset-container',
+    }
+  );
+};
+
+export {
+  generatePinPolicyHtml,
+};

--- a/test/unit/spec/v2/view-builder/views/nfcPin/EnrollNfcPinView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/nfcPin/EnrollNfcPinView_spec.js
@@ -86,6 +86,11 @@ describe('v2/view-builder/views/nfcPin/EnrollNfcPinView', function() {
       expect(testContext.view.$('[data-se="password-authenticator--rules"]').length).toBe(1);
     });
 
+    it('shows "Requirements:" header, not "Password requirements:"', function() {
+      const headerText = testContext.view.$('.password-authenticator--heading').text().trim();
+      expect(headerText).toBe('Requirements:');
+    });
+
     it('shows "Return to authenticator list" link in footer', function() {
       expect(testContext.view.$('.link[data-se="switchAuthenticator"]').length).toBe(1);
     });


### PR DESCRIPTION

## Description:
  **Bug:** When a user resets or creates their NFC PIN, the requirements section above the PIN field displayed "_**Password requirements:**_" instead of PIN-appropriate wording.

  **Root cause:** `EnrollNfcPinView` (v2/OIE engine) is shared by both the enroll-PIN and reset-PIN remediation flows (see `ViewFactory.ts`, `AUTHENTICATOR_KEY.NFC_PIN`). To render the requirements list, it called the shared `PasswordPolicyUtil.generatePasswordPolicyHtml()`, which hardcodes the `password.complexity.requirements.header` i18n key ("Password requirements:") in its Handlebars template. That key is correct for the password authenticator but incorrect for PIN.

  The v3 (React/Gen3) engine was never affected — it already resolves an independent, PIN-specific key
  (`oie.enroll.nfc_pin.create.requirements.header`) via `transformNfcPinCreate.ts`.

  **Fix:** Added a new `PinPolicyUtil.generatePinPolicyHtml()` used only by `EnrollNfcPinView`, which renders the existing
  `oie.enroll.nfc_pin.create.requirements.header` key ("Requirements:") instead of the password-specific one.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1259375](https://oktainc.atlassian.net/browse/OKTA-1259375)

### Reviewers:

### Screenshot/Video:

<img width="1717" height="1150" alt="Screenshot 2026-08-26 at 12 43 16 PM" src="https://github.com/user-attachments/assets/0ced76a3-fa1c-4c1d-a396-d70c2740d026" />

### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=3bd86d3258bf102a8d6568caa0e2312b253873c0&tab=main

**Cross Browser Test** - https://bacon-go.aue1e.saasure.net/tasks/CB_MULTI_BS?taskId=dfca2ac1d3534dc4aff087c6bc3cd46d

**Gen3 Nightly** - Not needed as this affects only Gen2.
