### PR TITLE
fix(Gen3): associate lone password field with form-level error

### DIFF
--- a/playground/mocks/config/test-configs/ChallengeAuthenticatorPassword.js
+++ b/playground/mocks/config/test-configs/ChallengeAuthenticatorPassword.js
@@ -25,8 +25,21 @@ const resetPasswordSuccess = {
   ]
 };
 
+// OKTA-1257415: the two-step password challenge returns a generic, non-attributive
+// "Unable to sign in" at form level. Used to verify the password input is associated with
+// that message via aria-describedby, without being marked aria-invalid.
+const wrongPasswordFormLevelError = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-password'
+  ],
+  '/idp/idx/challenge/answer': [
+    'error-401-authenticator-verify-password-generic'
+  ]
+};
+
 module.exports = {
   sessionExpiresDuringPassword,
   mockCannotForgotPassword,
-  resetPasswordSuccess
+  resetPasswordSuccess,
+  wrongPasswordFormLevelError
 };

--- a/playground/mocks/data/idp/idx/error-401-authenticator-verify-password-generic.json
+++ b/playground/mocks/data/idp/idx/error-401-authenticator-verify-password-generic.json
@@ -1,0 +1,315 @@
+{
+  "stateHandle": "eyJ6aXAiOiJERUYi",
+  "version": "1.0.0",
+  "expiresAt": "2020-05-05T16:58:36.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "challenge-authenticator",
+        "href": "http://localhost:3000/idp/idx/challenge/answer",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "credentials",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Password",
+                  "secret": true
+                }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYi",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "relatesTo": [
+          "$.currentAuthenticatorEnrollment"
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aidwboITrg4b4yAYd0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              },
+              {
+                "label": "Security Key or Biometric",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "fwftheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[1]"
+              },
+              {
+                "label": "Security Key or Biometric",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[2]"
+              },
+              {
+                "label": "Okta Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtm56L8gXXHI1SD0g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "email",
+                        "required": false,
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[3]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[4]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0HHSLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[5]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Authentication failed",
+        "i18n": {
+          "key": "errors.E0000004"
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "key": "okta_password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+      },
+      {
+        "displayName": "Security Key or Biometric",
+        "type": "security_key",
+        "key": "webauthn",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "aidtheidkwh282hv8g3"
+      },
+      {
+        "displayName": "Security Key or Biometric",
+        "type": "security_key",
+        "key": "webauthn",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "fwftheidkwh282hv8g3"
+      },
+      {
+        "displayName": "Okta Email",
+        "type": "email",
+        "key": "okta_email",
+        "authenticatorId": "aidtm56L8gXXHI1SD0g3",
+        "id": "autwa6eD9o02iBbtv0g3",
+        "methods": [
+          {
+            "methodType": "email"
+          }
+        ]
+      },
+      {
+        "displayName": "Okta Phone",
+        "type": "phone",
+        "key": "phone_number",
+        "authenticatorId": "aid568g3mXgtID0X1SLH",
+        "id": "autwa6eD9o02iBbsta82"
+      },
+      {
+        "displayName": "Okta Security Question",
+        "type": "security_question",
+        "key": "security_question",
+        "authenticatorId": "aid568g3mXgtID0HHSLH",
+        "id": "autwa6eD9o02iBbaaa82"
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment": {
+    "type": "object",
+    "value": {
+      "displayName": "Okta Password",
+      "profile": {
+        "name": "Okta Password"
+      },
+      "recover": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "recover",
+        "href": "http://localhost:3000/idp/idx/recover",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYi",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      "type": "password",
+      "key": "okta_password",
+      "authenticatorId": "autwa6eD9o02iBbtv0g1",
+      "id": "aidwboITrg4b4yAYd0g3"
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00uwb8GLwf1HED5Xs0g3",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "eyJ6aXAiOiJERUYi",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  }
+}

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -36,10 +36,32 @@ const InfoBox: UISchemaElementComponent<{
       message,
       class: messageClass,
       dataSe,
+      messageId,
     },
   } = uischema;
 
   const tokens = useOdysseyDesignTokens();
+
+  const messageContent = Array.isArray(message)
+    ? message.map((msg) => (
+      <Box
+        marginBlockEnd={tokens.Spacing2}
+        key={msg.message}
+      >
+        <WidgetMessageContainer
+          key={msg.message}
+          message={msg}
+          parserOptions={{ replace: getLinkReplacerFn({}, 'monochrome') }}
+          linkVariant="monochrome"
+        />
+      </Box>
+    ))
+    : (
+      <WidgetMessageContainer
+        message={message}
+        linkVariant="monochrome"
+      />
+    );
 
   return loading ? null : (
     <Box
@@ -52,28 +74,13 @@ const InfoBox: UISchemaElementComponent<{
         // visually-hidden severity text is not translated
         translate="no"
       >
-        {
-          Array.isArray(message)
-            ? message.map((msg) => (
-              <Box
-                marginBlockEnd={tokens.Spacing2}
-                key={msg.message}
-              >
-                <WidgetMessageContainer
-                  key={msg.message}
-                  message={msg}
-                  parserOptions={{ replace: getLinkReplacerFn({}, 'monochrome') }}
-                  linkVariant="monochrome"
-                />
-              </Box>
-            ))
-            : (
-              <WidgetMessageContainer
-                message={message}
-                linkVariant="monochrome"
-              />
-            )
-        }
+        {/*
+          * When another element references this message, expose the id on a wrapper around the
+          * message content only, excluding the Callout's icon and visually-hidden severity text,
+          * so that aria-describedby resolves to the message alone.
+          * See updatePasswordDescribedByFormError.
+          */}
+        {messageId ? <Box id={messageId}>{messageContent}</Box> : messageContent}
       </Callout>
     </Box>
   );

--- a/src/v3/src/transformer/uischema/transform.test.ts
+++ b/src/v3/src/transformer/uischema/transform.test.ts
@@ -36,6 +36,9 @@ jest.mock('./applyAsteriskToFieldElements', () => ({
 jest.mock('./updatePasswordDescribedByValue', () => ({
   updatePasswordDescribedByValue: () => ({}),
 }));
+jest.mock('./updatePasswordDescribedByFormError', () => ({
+  updatePasswordDescribedByFormError: () => ({}),
+}));
 jest.mock('./overwriteAutocomplete', () => ({
   overwriteAutocomplete: () => () => ({}),
 }));
@@ -55,6 +58,7 @@ const mocked = {
   setFocus: require('./setFocusOnFirstElement'),
   applyAsterisk: require('./applyAsteriskToFieldElements'),
   updatePasswordEle: require('./updatePasswordDescribedByValue'),
+  updatePasswordFormError: require('./updatePasswordDescribedByFormError'),
   overwriteAutocomplete: require('./overwriteAutocomplete'),
   createIdentifierContainer: require('./createIdentifierContainer'),
   addWebAuthNAutofillHandler: require('./addWebAuthNAutofillHandler'),
@@ -70,6 +74,7 @@ describe('UISchema transformer', () => {
     jest.spyOn(mocked.setFocus, 'setFocusOnFirstElement');
     jest.spyOn(mocked.applyAsterisk, 'applyAsteriskToFieldElements');
     jest.spyOn(mocked.updatePasswordEle, 'updatePasswordDescribedByValue');
+    jest.spyOn(mocked.updatePasswordFormError, 'updatePasswordDescribedByFormError');
     jest.spyOn(mocked.overwriteAutocomplete, 'overwriteAutocomplete');
     jest.spyOn(mocked.createIdentifierContainer, 'createIdentifierContainer');
     jest.spyOn(mocked.addWebAuthNAutofillHandler, 'addWebAuthNAutofillHandler');
@@ -87,6 +92,12 @@ describe('UISchema transformer', () => {
       .toHaveBeenCalledBefore(
         mocked.updatePasswordEle.updatePasswordDescribedByValue,
       );
+    // Must run after updatePasswordDescribedByValue so that the two aria-describedby values
+    // compose rather than overwrite one another
+    expect(mocked.updatePasswordEle.updatePasswordDescribedByValue)
+      .toHaveBeenCalledBefore(
+        mocked.updatePasswordFormError.updatePasswordDescribedByFormError,
+      );
 
     expect(mocked.createTextEleKey.createTextElementKeys).toHaveBeenCalled();
     expect(mocked.updateEleKey.updateElementKeys).toHaveBeenCalled();
@@ -95,6 +106,7 @@ describe('UISchema transformer', () => {
     expect(mocked.setFocus.setFocusOnFirstElement).toHaveBeenCalled();
     expect(mocked.applyAsterisk.applyAsteriskToFieldElements).toHaveBeenCalled();
     expect(mocked.updatePasswordEle.updatePasswordDescribedByValue).toHaveBeenCalled();
+    expect(mocked.updatePasswordFormError.updatePasswordDescribedByFormError).toHaveBeenCalled();
     expect(mocked.overwriteAutocomplete.overwriteAutocomplete).toHaveBeenCalled();
     expect(mocked.createIdentifierContainer.createIdentifierContainer).toHaveBeenCalled();
     expect(mocked.addWebAuthNAutofillHandler.addWebAuthNAutofillHandler).toHaveBeenCalled();

--- a/src/v3/src/transformer/uischema/transform.ts
+++ b/src/v3/src/transformer/uischema/transform.ts
@@ -24,6 +24,7 @@ import { overwriteAutocomplete } from './overwriteAutocomplete';
 import { setFocusOnFirstElement } from './setFocusOnFirstElement';
 import { updateCustomFields } from './updateCustomFields';
 import { updateElementKeys } from './updateElementKeys';
+import { updatePasswordDescribedByFormError } from './updatePasswordDescribedByFormError';
 import { updatePasswordDescribedByValue } from './updatePasswordDescribedByValue';
 
 export const transformUISchema: TransformStepFnWithOptions = (
@@ -36,6 +37,8 @@ export const transformUISchema: TransformStepFnWithOptions = (
   updateElementKeys(options),
   addIdToElements,
   updatePasswordDescribedByValue,
+  // Must run after updatePasswordDescribedByValue so the two describedby values compose
+  updatePasswordDescribedByFormError,
   overwriteAutocomplete(options),
   // OKTA-586475: Please keep this as the last function to be executed since we want to ensure
   // that the identifier container is always positioned at the top of a view

--- a/src/v3/src/transformer/uischema/updatePasswordDescribedByFormError.test.ts
+++ b/src/v3/src/transformer/uischema/updatePasswordDescribedByFormError.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { getStubFormBag } from 'src/mocks/utils/utils';
+import {
+  ButtonElement,
+  ButtonType,
+  FieldElement,
+  FormBag,
+  InfoboxElement,
+  TitleElement,
+  UISchemaElement,
+} from 'src/types';
+
+import {
+  FORM_ERROR_MESSAGE_ID,
+  updatePasswordDescribedByFormError,
+} from './updatePasswordDescribedByFormError';
+
+const errorInfobox = (): InfoboxElement => ({
+  type: 'InfoBox',
+  options: {
+    class: 'ERROR',
+    message: { message: 'Unable to sign in' },
+    dataSe: 'callout',
+  },
+} as InfoboxElement);
+
+const passwordField = (): FieldElement => ({
+  type: 'Field',
+  options: { inputMeta: { name: 'credentials.passcode', secret: true } },
+} as FieldElement);
+
+describe('updatePasswordDescribedByFormError Tests', () => {
+  let formBag: FormBag;
+
+  beforeEach(() => {
+    // Mirrors the identifier-first challenge-authenticator view: a single password field
+    formBag = getStubFormBag();
+    formBag.uischema.elements = [
+      errorInfobox(),
+      { type: 'Title', id: 'title_1', options: { content: 'Verify with your password' } } as TitleElement,
+      passwordField(),
+      { type: 'Button', id: 'button_1', options: { type: ButtonType.SUBMIT } } as ButtonElement,
+    ];
+  });
+
+  const describedByOf = (bag: FormBag, index: number) => (
+    (bag.uischema.elements[index] as UISchemaElement).ariaDescribedBy
+  );
+
+  it('should associate the lone password field with the form-level error', () => {
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    expect(describedByOf(updatedFormBag, 2)).toBe(FORM_ERROR_MESSAGE_ID);
+  });
+
+  it('should append to an existing aria-describedby value rather than replace it', () => {
+    (formBag.uischema.elements[2] as UISchemaElement).ariaDescribedBy = 'PasswordRequirements_abc123';
+
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    expect(describedByOf(updatedFormBag, 2))
+      .toBe(`PasswordRequirements_abc123 ${FORM_ERROR_MESSAGE_ID}`);
+  });
+
+  it('should not associate any field when the view renders more than one field', () => {
+    // The combined username + password sign-in form: a failed credential check is not
+    // attributable to a single field, so neither field is associated with the error.
+    formBag.uischema.elements = [
+      errorInfobox(),
+      { type: 'Field', options: { inputMeta: { name: 'identifier' } } } as FieldElement,
+      passwordField(),
+      { type: 'Field', options: { inputMeta: { name: 'rememberMe' } } } as FieldElement,
+    ];
+
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    expect(describedByOf(updatedFormBag, 1)).toBeUndefined();
+    expect(describedByOf(updatedFormBag, 2)).toBeUndefined();
+    expect(describedByOf(updatedFormBag, 3)).toBeUndefined();
+  });
+
+  it('should not associate the field when there is no form-level error', () => {
+    formBag.uischema.elements = formBag.uischema.elements.filter(
+      (element) => element.type !== 'InfoBox',
+    );
+
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    expect(describedByOf(updatedFormBag, 1)).toBeUndefined();
+  });
+
+  it('should not associate the field when the form-level message is not an error', () => {
+    (formBag.uischema.elements[0] as InfoboxElement).options.class = 'WARNING';
+
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    expect(describedByOf(updatedFormBag, 2)).toBeUndefined();
+  });
+
+  it('should not associate the field when the lone field is not a password', () => {
+    formBag.uischema.elements[2] = {
+      type: 'Field',
+      options: { inputMeta: { name: 'credentials.passcode' } },
+    } as FieldElement;
+
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    expect(describedByOf(updatedFormBag, 2)).toBeUndefined();
+  });
+
+  it('should not associate the field when there are multiple form-level errors', () => {
+    formBag.uischema.elements.unshift(errorInfobox());
+
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    expect(describedByOf(updatedFormBag, 3)).toBeUndefined();
+  });
+
+  it('should expose the message id on the error element so the reference resolves', () => {
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    const errorElement = updatedFormBag.uischema.elements[0] as InfoboxElement;
+    expect(errorElement.options.messageId).toBe(FORM_ERROR_MESSAGE_ID);
+    expect(describedByOf(updatedFormBag, 2)).toContain(FORM_ERROR_MESSAGE_ID);
+  });
+
+  it('should not expose a message id when the guard does not match', () => {
+    formBag.uischema.elements = formBag.uischema.elements.filter(
+      (element) => element.type !== 'Field',
+    );
+
+    const updatedFormBag = updatePasswordDescribedByFormError(formBag);
+
+    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options.messageId)
+      .toBeUndefined();
+  });
+});

--- a/src/v3/src/transformer/uischema/updatePasswordDescribedByFormError.ts
+++ b/src/v3/src/transformer/uischema/updatePasswordDescribedByFormError.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  FieldElement, InfoboxElement, TransformStepFn,
+} from '../../types';
+import { traverseLayout } from '../util';
+
+/**
+ * Id applied to the form-level error message when a password input references it. Namespaced
+ * against the host page the widget is embedded in — a bare id such as "form-error" could
+ * collide with the customer's own markup, which would make aria-describedby resolve to the
+ * wrong element.
+ */
+export const FORM_ERROR_MESSAGE_ID = 'okta-sign-in-form-error';
+
+/**
+ * Associates a lone password input with a form-level error message via `aria-describedby`, so
+ * that a screen reader user returning to the field is informed of the outstanding error. Without
+ * this, the error is announced once by the `role="alert"` container and the field itself conveys
+ * nothing on re-focus.
+ *
+ * Deliberately scoped to views that render exactly one field which is a password — i.e. the
+ * identifier-first `challenge-authenticator` step. On views with several inputs, such as the
+ * combined username + password sign-in form, a failed credential check is not attributable to
+ * any single field, so no field is associated with the error.
+ *
+ * Note this adds a description only. It intentionally does not set `aria-invalid`, which per
+ * WAI-ARIA asserts that "the value entered by the user has failed validation". The server
+ * returns a generic form-level message and does not attribute the failure to a field, so the
+ * widget does not either.
+ */
+export const updatePasswordDescribedByFormError: TransformStepFn = (formbag) => {
+  const fieldElements: FieldElement[] = [];
+  const errorElements: InfoboxElement[] = [];
+
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (el) => el.type === 'Field' || el.type === 'InfoBox',
+    callback: (el) => {
+      if (el.type === 'Field') {
+        fieldElements.push(el as FieldElement);
+      } else if ((el as InfoboxElement).options?.class === 'ERROR') {
+        errorElements.push(el as InfoboxElement);
+      }
+    },
+  });
+
+  // Only the unambiguous case: a single password field and a single form-level error.
+  if (fieldElements.length !== 1 || errorElements.length !== 1) {
+    return formbag;
+  }
+
+  const [field] = fieldElements;
+  const [errorElement] = errorElements;
+
+  if (!field.options.inputMeta.secret) {
+    return formbag;
+  }
+
+  errorElement.options.messageId = FORM_ERROR_MESSAGE_ID;
+  field.ariaDescribedBy = typeof field.ariaDescribedBy === 'undefined'
+    ? FORM_ERROR_MESSAGE_ID
+    : `${field.ariaDescribedBy} ${FORM_ERROR_MESSAGE_ID}`;
+
+  return formbag;
+};

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -687,6 +687,12 @@ export interface InfoboxElement extends UISchemaElement {
     message: WidgetMessage | WidgetMessage[];
     class: string;
     dataSe?: string;
+    /**
+     * When set, rendered as the id of a wrapper around the message content so that other
+     * elements can reference the message via aria-describedby. Only set when something
+     * actually references it. See updatePasswordDescribedByFormError.
+     */
+    messageId?: string;
   }
 }
 

--- a/src/v3/test/integration/__snapshots__/error-authenticator-verify-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-verify-password.test.tsx.snap
@@ -1,0 +1,327 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`error-authenticator-verify-password should render form 1`] = `
+<div>
+  <div
+    class="emotion-0"
+  >
+    <div
+      class="MuiScopedCssBaseline-root emotion-1"
+    >
+      <main
+        class="MuiBox-root emotion-2"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-se="auth-container main-container"
+        data-version="0.0.0"
+        dir="ltr"
+        id="okta-sign-in"
+        lang="en"
+      >
+        <div
+          class="MuiScopedCssBaseline-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiBox-root emotion-5"
+            >
+              <div
+                class="MuiBox-root emotion-6"
+                data-se="okta-sign-in-header auth-header authCoinSpacing"
+              >
+                <h1
+                  class="MuiTypography-root MuiTypography-h1 emotion-7"
+                  role="presentation"
+                  tabindex="-1"
+                />
+                <div
+                  aria-hidden="true"
+                  class="MuiBox-root emotion-8"
+                  data-se="factor-beacon mfa-okta-password "
+                >
+                  <svg
+                    aria-labelledby="mfa-okta-password"
+                    fill="none"
+                    height="2.85714286rem"
+                    role="img"
+                    viewBox="0 0 48 48"
+                    width="2.85714286rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <title
+                      id="mfa-okta-password"
+                    >
+                      Password
+                    </title>
+                    <path
+                      class="siwFillSecondary"
+                      d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
+                      fill="#A7B5EC"
+                    />
+                    <path
+                      class="siwFillPrimaryDark"
+                      d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
+                      fill="#00297A"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-9"
+              >
+                <form
+                  aria-live="polite"
+                  class="o-form MuiBox-root emotion-10"
+                  data-se="o-form"
+                  novalidate=""
+                >
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <div
+                        class="MuiBox-root emotion-13"
+                        data-se="identifier-container"
+                        title="testUser@okta.com"
+                      >
+                        <div
+                          class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-14"
+                          data-se="identifier"
+                          translate="no"
+                        >
+                          <div
+                            class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-15"
+                          >
+                            <svg
+                              aria-label="User"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-16"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M15.5 6.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Zm2 0a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0ZM5 23c0-2.357.694-4.363 1.886-5.762C8.064 15.856 9.782 15 12 15c2.215 0 3.934.862 5.113 2.25C18.307 18.652 19 20.66 19 23h2c0-2.722-.807-5.216-2.363-7.046C17.067 14.107 14.785 13 12 13c-2.782 0-5.064 1.097-6.636 2.941C3.806 17.77 3 20.263 3 23h2Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                User
+                              </title>
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiChip-label MuiChip-labelMedium emotion-17"
+                          >
+                            testUser@okta.com
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <div
+                        class="MuiBox-root emotion-19"
+                        data-se="infobox-error"
+                      >
+                        <div
+                          aria-label="error"
+                          aria-labelledby="82mvyq"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-calloutError MuiAlert-callout emotion-20"
+                          data-se="callout"
+                          role="alert"
+                        >
+                          <div
+                            class="MuiAlert-icon emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-22"
+                              fill="none"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            class="MuiAlert-message emotion-23"
+                          >
+                            <div
+                              class="emotion-24"
+                            >
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <div
+                                  class="MuiBox-root emotion-2"
+                                  id="okta-sign-in-form-error"
+                                >
+                                  Unable to sign in
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <div
+                        class="MuiBox-root emotion-28"
+                      >
+                        <h1
+                          class="MuiTypography-root MuiTypography-h4 emotion-29"
+                          data-se="o-form-head"
+                          tabindex="-1"
+                        >
+                          Verify with your password
+                        </h1>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-2"
+                    >
+                      <input
+                        class="MuiBox-root emotion-31"
+                        id="username"
+                        name="username"
+                        type="text"
+                      />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <div
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-33"
+                      >
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-34"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
+                        >
+                          <span>
+                            Password
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-35"
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="okta-sign-in-form-error"
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="current-password"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-36"
+                            data-se="credentials.passcode"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            role="textbox"
+                            type="password"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-37"
+                          >
+                            <button
+                              aria-controls="credentials.passcode"
+                              aria-label="Show password"
+                              aria-pressed="false"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-38"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-22"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M3.43 12.813A12.814 12.814 0 0 1 3.069 12a14.153 14.153 0 0 1 1.966-3.38C6.506 6.762 8.746 5 12 5s5.494 1.761 6.966 3.62A14.152 14.152 0 0 1 20.932 12a14.151 14.151 0 0 1-1.966 3.38C17.494 17.238 15.254 19 12 19s-5.494-1.761-6.966-3.62a14.152 14.152 0 0 1-1.603-2.567Zm19.518-1.13L22 12c.949.316.949.317.948.317v.004l-.003.007-.008.024a7.012 7.012 0 0 1-.137.362 16.147 16.147 0 0 1-2.266 3.906C18.84 18.762 16.08 21 12 21c-4.08 0-6.84-2.239-8.534-4.38A16.15 16.15 0 0 1 1.2 12.715a10.039 10.039 0 0 1-.137-.362l-.008-.024-.002-.007-.001-.003c0-.001 0-.002.948-.318a91.698 91.698 0 0 1-.948-.317v-.004l.003-.007.008-.024.029-.08c.025-.067.06-.163.108-.282A16.15 16.15 0 0 1 3.466 7.38C5.16 5.24 7.92 3 12 3c4.08 0 6.84 2.239 8.534 4.38a16.147 16.147 0 0 1 2.266 3.906 10.026 10.026 0 0 1 .137.362l.008.024.002.007.001.003ZM2 12l-.949.316L.946 12l.105-.316L2 12Zm20 0 .949-.316.105.316-.105.316L22 12ZM9 12a3 3 0 1 1 6 0 3 3 0 0 1-6 0Zm3-5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-41"
+                        data-se="save"
+                        tabindex="0"
+                        type="submit"
+                      >
+                        Verify
+                      </button>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <button
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
+                        data-se="forgot-password"
+                        role="link"
+                        type="button"
+                      >
+                        Forgot password?
+                      </button>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <button
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
+                        data-se="switchAuthenticator"
+                        role="link"
+                        type="button"
+                      >
+                        Verify with something else
+                      </button>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <button
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
+                        data-se="cancel"
+                        role="link"
+                        type="button"
+                      >
+                        Back to sign in
+                      </button>
+                    </div>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+</div>
+`;

--- a/src/v3/test/integration/error-authenticator-verify-password.test.tsx
+++ b/src/v3/test/integration/error-authenticator-verify-password.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { setup } from './util';
+
+import mockResponse from '../../../../playground/mocks/data/idp/idx/error-401-authenticator-verify-password-generic.json';
+
+describe('error-authenticator-verify-password', () => {
+  it('should render form', async () => {
+    const { container, findByText } = await setup({ mockResponse });
+
+    await findByText(/Unable to sign in/);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should associate the password field with the form-level error via aria-describedby', async () => {
+    const { container, findByText } = await setup({ mockResponse });
+
+    await findByText(/Unable to sign in/);
+
+    const passwordInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(passwordInput).not.toBeNull();
+
+    const describedByIds = (passwordInput?.getAttribute('aria-describedby') ?? '')
+      .split(' ')
+      .filter(Boolean);
+    expect(describedByIds).not.toHaveLength(0);
+
+    // The referenced element must exist and resolve to the error text alone, so that a screen
+    // reader returning to the field announces the outstanding error.
+    const describedByText = describedByIds
+      .map((id) => container.ownerDocument.getElementById(id)?.textContent ?? '')
+      .join(' ');
+    expect(describedByText).toContain('Unable to sign in');
+  });
+
+  it('should not mark the password field invalid when the error is form-level', async () => {
+    // The server returns a generic message and does not attribute the failure to a field, so
+    // neither does the widget. aria-invalid asserts the entered value failed validation.
+    const { container, findByText } = await setup({ mockResponse });
+
+    await findByText(/Unable to sign in/);
+
+    const passwordInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(passwordInput?.getAttribute('aria-invalid')).toBe('false');
+    expect(passwordInput?.hasAttribute('aria-errormessage')).toBe(false);
+  });
+
+  it('should announce the error through a live region', async () => {
+    const { container, findByText } = await setup({ mockResponse });
+
+    await findByText(/Unable to sign in/);
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('Unable to sign in');
+  });
+});

--- a/src/v3/test/integration/identify-with-password-error-field-association.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-field-association.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { setup } from './util';
+
+import * as cookieUtils from '../../src/util/cookieUtils';
+import mockResponse from '../../src/mocks/response/idp/idx/introspect/default.json';
+import wrongPasswordMockResponse from '../../src/mocks/response/idp/idx/identify/error-wrong-password.json';
+
+// Lives in its own file: the integration harness keeps auth-js transaction state for the
+// lifetime of a test file, so a flow that submits a remediation is only reliable as the
+// first setup() in that file.
+describe('identify-with-password-error-field-association', () => {
+  it('should not associate either field with the form-level error after a failed sign in', async () => {
+    jest.spyOn(cookieUtils, 'getUsernameCookie').mockReturnValue('testuser@okta1.com');
+    const {
+      container,
+      user,
+      findByText,
+      findByLabelText,
+    } = await setup({
+      mockResponses: {
+        '/introspect': {
+          data: mockResponse,
+          status: 200,
+        },
+        '/idp/idx/identify': {
+          data: wrongPasswordMockResponse,
+          status: 401,
+        },
+      },
+      widgetOptions: { features: { rememberMe: true } },
+    });
+
+    const submitButton = await findByText('Sign in', { selector: 'button' });
+    const initialUsernameEl = await findByLabelText('Username') as HTMLInputElement;
+    const initialPasswordEl = await findByLabelText('Password') as HTMLInputElement;
+
+    await user.clear(initialUsernameEl);
+    await user.type(initialUsernameEl, 'testuser@okta1.com');
+    await user.type(initialPasswordEl, 'wrongPassword1234');
+    await user.click(submitButton);
+
+    await findByText('Unable to sign in');
+
+    const describedText = (el: HTMLElement) => (el.getAttribute('aria-describedby') ?? '')
+      .split(' ')
+      .filter(Boolean)
+      .map((id) => container.ownerDocument.getElementById(id)?.textContent ?? '')
+      .join(' ');
+
+    const usernameEl = await findByLabelText('Username') as HTMLInputElement;
+    const passwordEl = await findByLabelText('Password') as HTMLInputElement;
+
+    // A failed credential check on the combined form is not attributable to either field.
+    // Associating or invalidating one would imply the other was accepted, which is a
+    // user-enumeration signal. The error stays form-level.
+    expect(describedText(usernameEl)).not.toContain('Unable to sign in');
+    expect(describedText(passwordEl)).not.toContain('Unable to sign in');
+    expect(usernameEl.getAttribute('aria-invalid')).toBe('false');
+    expect(passwordEl.getAttribute('aria-invalid')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Description:

On the identifier-first password challenge, a failed credential check renders a form-level error alert above the form. The alert is announced once on insertion, but the password input itself conveyed nothing, so a screen reader user returning to the field received no indication of the outstanding error.

Give the message an id and reference it from the password input via aria-describedby, so focusing the field announces the error. No visual change.

Scoped to views rendering exactly one field which is a password. On the combined username + password form the server returns a generic message (errors.E0000004, identical for a wrong password and an unknown user), so the failure is not attributable to either field; associating one would imply the other was accepted, which is a user-enumeration signal. An integration test locks that in.

The id is carried on a new InfoboxElement options.messageId, set only when something references it, so no other view's markup changes. It is namespaced as okta-sign-in-form-error rather than a bare "form-error", which could collide with the markup of the page embedding the widget.

aria-invalid is deliberately left as "false". Per WAI-ARIA it asserts that "the value entered by the user has failed validation", which the server does not assert. Odyssey also derives aria-invalid and aria-errormessage solely from its errorMessage prop, so setting them would require rendering duplicate visible error text. aria-describedby is the supported mechanism and is what the W3C WAI forms guidance names for associating a field with an error message.

And Odyssey doesn't expose `aria-invalid` and `aria-errormessage` to us, ideally we need to open a feature request to Odyssey team and update Odyssey, which is high effort and high risk, so only update `ariaDescribedBy` is a quick mitigation


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1257415](https://oktainc.atlassian.net/browse/OKTA-1257415)

### Reviewers:

### Screenshot/Video:

#### without fix
After submitting wrong password, the form level "Unable to Sign in" element shows, but when tabbing to the password field, no error message on VoiceOver
Screenshot:
<img width="1710" height="951" alt="Screenshot 2026-09-04 at 4 04 44 PM" src="https://github.com/user-attachments/assets/ba1fbb6e-992e-40ef-9523-b8f0d8fea46a" />

Video:

https://github.com/user-attachments/assets/e4fefe94-e910-45e5-bfb5-e2ec7766d8ce

#### after fix
After submitting wrong password, the form level "Unable to Sign in" element shows, but we use `aria-describedby` to point to the form-level error, so when tabbing to the password field, error message is read on VoiceOver
Screenshot:
<img width="1709" height="950" alt="Screenshot 2026-09-04 at 4 38 33 PM" src="https://github.com/user-attachments/assets/41bf9b88-0e5c-43b4-8068-9a11fb77a7e4" />

Video:

https://github.com/user-attachments/assets/06bbecb0-2f60-41d2-9e53-630e27179b25



### Downstream Monolith Build:





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accessibility for generic password-verification errors by linking the form-level message to the password field.
  - Preserved existing accessibility descriptions while ensuring error messages are announced correctly.
  - Corrected error presentation so generic sign-in failures are not incorrectly shown as field-specific validation errors.

- **Tests**
  - Added coverage for incorrect-password flows, error announcements, form rendering, and accessibility relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->